### PR TITLE
[#75] Add reopen workflow design

### DIFF
--- a/projects/botminter/knowledge/designs/epic-75.md
+++ b/projects/botminter/knowledge/designs/epic-75.md
@@ -1,0 +1,315 @@
+# Design: Reopen Workflow for Issues
+
+**Epic:** #75 — Reopen Workflow for Issues
+**Date:** 2026-05-14
+**Project:** botminter
+
+---
+
+## Overview
+
+### Problem
+
+When an issue reaches `done` and is closed, there is no defined path for reopening it. Regressions, incomplete fixes, or new information can require an issue to re-enter the pipeline, but today the team has no convention for:
+
+- Who decides to reopen an issue
+- What status a reopened issue transitions to
+- How to preserve the original resolution context
+- How the board scanner detects and dispatches reopened issues
+
+The existing rejection loops in PROCESS.md only cover in-flight issues (e.g., `eng:qe:verify` back to `eng:dev:implement`). Once an issue is closed and at `done`, there is no re-entry point.
+
+### Solution
+
+Define a reopen workflow that integrates into the existing status graph. A reopened issue re-enters the pipeline at one of three target statuses depending on the reason for reopening. The `close-reopen.sh` script is extended to accept a `--target-status` parameter, and the board scanner treats reopened issues identically to any other issue at its assigned status — no new scanner logic is required.
+
+### Scope
+
+- Define reopen triggers and target statuses in PROCESS.md
+- Define the comment convention for reopen attribution
+- Extend `close-reopen.sh` to optionally set a target status on reopen
+- Document interaction with epics, stories, and bugs
+
+### Out of Scope
+
+- Automated regression detection (detecting that a fix broke)
+- New board statuses — the reopen workflow uses existing statuses
+- Changes to the board scanner dispatch tables
+- Changes to the sentinel merge gate
+- Automated linking between a reopened issue and the regression trigger
+
+---
+
+## Architecture
+
+### Reopen as a Status Graph Re-Entry
+
+The reopen workflow does not add new statuses. Instead, it defines a re-entry edge from `done` (terminal) back into the existing status graph at one of three target statuses, depending on the reason for reopening.
+
+```mermaid
+stateDiagram-v2
+    done --> eng:po:triage : requirements changed
+    done --> eng:bug:investigate : regression / incomplete fix (bugs)
+    done --> eng:dev:implement : incomplete fix (stories)
+    done --> eng:qe:test-design : scope missed during original work (stories)
+
+    note right of done
+      Reopen requires:
+      1. GitHub issue reopened
+      2. Status set to target
+      3. Attribution comment posted
+    end note
+```
+
+### Trigger Model
+
+A reopen is always a **deliberate human or agent action**, not an automatic detection. The trigger is a two-step operation:
+
+1. **Reopen the GitHub issue** (changes state from `closed` to `open`)
+2. **Set the project board status** to the appropriate target
+
+Both steps are performed via the `close-reopen.sh` script (extended with `--target-status`). Without step 2, the reopened issue has no status and the board scanner will not pick it up.
+
+### Who Can Reopen
+
+Any hat or human that identifies the need for rework:
+
+| Actor | Typical Scenario |
+|-------|-----------------|
+| **Human (PO)** | Requirements changed, acceptance was premature |
+| **QE (qe_verifier / qe_investigator)** | Regression discovered during later verification |
+| **Dev (dev_implementer)** | Incomplete fix discovered during later story work |
+| **Architect (arch_monitor)** | Epic-level regression detected during monitoring |
+
+The actor reopening the issue MUST post an attribution comment explaining the reason.
+
+### Target Status by Reason
+
+| Reason | Issue Type | Target Status | Rationale |
+|--------|-----------|---------------|-----------|
+| Requirements changed | Epic | `eng:po:triage` | Needs full re-evaluation |
+| Requirements changed | Story | `eng:po:triage` | Needs re-scoping |
+| Requirements changed | Bug | `eng:po:triage` | Needs re-evaluation |
+| Regression discovered | Bug | `eng:bug:investigate` | QE must reproduce and analyze the regression |
+| Incomplete fix (simple) | Story | `eng:dev:implement` | Known scope — go straight to implementation |
+| Incomplete fix (complex) | Story | `eng:qe:test-design` | Needs new test coverage for missed scope |
+| Incomplete fix | Bug (simple) | `eng:bug:investigate` | Re-investigate to understand what was missed |
+| Incomplete fix | Bug (complex) | `eng:bug:in-progress` | Subtasks may need additions |
+
+**Default rule:** When in doubt, reopen to `eng:po:triage`. It is safer to re-triage than to skip evaluation.
+
+### Epic Reopen Behavior
+
+When an epic is reopened:
+
+- The epic itself moves to the target status (usually `eng:po:triage`)
+- Existing stories under the epic are NOT automatically reopened
+- If specific stories need rework, they are reopened individually
+- If new stories are needed, they are created through the normal `eng:arch:breakdown` flow after the epic progresses through design/planning again
+
+### History Preservation
+
+Reopened issues MUST preserve all existing context:
+
+- **No clearing of comments** — all prior work, reviews, and decisions remain
+- **No clearing of labels** — existing labels are preserved; a `reopen` label is NOT required (the comment trail provides audit)
+- **No clearing of milestone** — the issue stays in its milestone (the PO can reassign if needed)
+- **PR history** — merged PRs from the original resolution remain merged. New work creates new PRs on new branches
+
+The reopen attribution comment (see Comment Convention below) provides a clear marker in the issue timeline separating the original resolution from the rework.
+
+---
+
+## Components and Interfaces
+
+### Component 1: PROCESS.md Update
+
+Add a new "Reopen Workflow" section to PROCESS.md documenting:
+
+- The reopen trigger model (two-step: reopen issue + set status)
+- The target status table
+- The comment convention
+- The history preservation rules
+
+This is the authoritative reference. All other changes implement what PROCESS.md defines.
+
+### Component 2: `close-reopen.sh` Extension
+
+**File:** `team/coding-agent/skills/github-project/scripts/close-reopen.sh`
+
+**Current interface:**
+
+```bash
+close-reopen.sh --issue <number> --action <close|reopen>
+```
+
+**Extended interface:**
+
+```bash
+close-reopen.sh --issue <number> --action <close|reopen> [--target-status <status>]
+```
+
+When `--action reopen` is used with `--target-status`:
+
+1. Reopen the GitHub issue (`gh issue reopen`)
+2. Look up the project item ID for the issue
+3. Look up the option ID for the target status
+4. Set the status via `gh project item-edit`
+5. Post an auto-transition comment noting the reopen and target status
+
+When `--target-status` is omitted on reopen, the issue is reopened but no status is set. This preserves backward compatibility but means the board scanner will not pick it up until a status is manually assigned.
+
+**Validation:** The script validates that `--target-status` is only used with `--action reopen`. Using it with `--action close` is an error.
+
+### Component 3: Comment Convention
+
+Reopen comments use the standard format with the acting persona:
+
+```markdown
+### <emoji> <persona> — <ISO-8601-UTC-timestamp>
+
+**Reopened** — <reason category>
+
+<explanation of why the issue is being reopened, with links to the
+regression, new information, or incomplete scope>
+
+**Target status:** `<target-status>`
+**Original resolution:** <date or link to the closing comment>
+```
+
+Example:
+
+```markdown
+### 🧪 qe — 2026-05-14T10:30:00Z
+
+**Reopened** — regression discovered
+
+Story #42 introduced a regression in the authentication flow. The session
+handler now fails when the user has multiple active sessions. See #88
+for the regression report.
+
+**Target status:** `eng:bug:investigate`
+**Original resolution:** 2026-05-10T14:00:00Z
+```
+
+### Component 4: Board Scanner Behavior
+
+**No changes required.** The board scanner dispatches based on the status field value, not on whether an issue was previously closed. Once a reopened issue has its status set (via `close-reopen.sh --target-status`), the scanner picks it up on the next scan cycle and dispatches to the appropriate hat, exactly as it would for any other issue at that status.
+
+The scanner already skips `done` and `error` statuses. A reopened issue at `done` (status not yet changed) is skipped — this is correct behavior. The status must be explicitly set to a non-terminal value for the scanner to act on it.
+
+---
+
+## Acceptance Criteria
+
+### AC1: PROCESS.md documents the reopen workflow
+
+**Given** the current PROCESS.md has no reopen workflow section
+**When** the epic is implemented
+**Then** PROCESS.md contains a "Reopen Workflow" section that documents:
+  - The two-step trigger model (reopen + set status)
+  - The target status table (reason x issue type -> status)
+  - The comment convention with example
+  - The history preservation rules
+  - The default rule ("when in doubt, reopen to `eng:po:triage`")
+
+### AC2: `close-reopen.sh` accepts `--target-status` on reopen
+
+**Given** an issue at status `done` that is closed
+**When** `close-reopen.sh --issue 42 --action reopen --target-status eng:dev:implement` is run
+**Then** the issue is reopened AND its project board status is set to `eng:dev:implement`
+
+### AC3: `close-reopen.sh` rejects `--target-status` on close
+
+**Given** an open issue
+**When** `close-reopen.sh --issue 42 --action close --target-status eng:dev:implement` is run
+**Then** the script exits with an error message indicating `--target-status` is only valid with `--action reopen`
+
+### AC4: `close-reopen.sh` backward compatibility preserved
+
+**Given** an issue at status `done` that is closed
+**When** `close-reopen.sh --issue 42 --action reopen` is run (no `--target-status`)
+**Then** the issue is reopened but no status change is made (existing behavior)
+
+### AC5: Board scanner picks up reopened issues
+
+**Given** a closed issue at status `done`
+**When** the issue is reopened and its status is set to `eng:bug:investigate`
+**Then** on the next board scan cycle, the scanner dispatches the issue to the `qe.investigate` event, identical to a newly created bug at that status
+
+### AC6: Reopen attribution comment is posted
+
+**Given** an issue being reopened
+**When** the reopen is performed (via script or manually)
+**Then** a comment following the standard format is posted on the issue, including:
+  - The reason category (regression, incomplete fix, requirements changed)
+  - An explanation linking to the trigger
+  - The target status
+  - Reference to the original resolution
+
+### AC7: Epic reopen does not cascade to stories
+
+**Given** a completed epic with three completed stories
+**When** the epic is reopened to `eng:po:triage`
+**Then** the three stories remain at `done` and closed; only the epic re-enters the pipeline
+
+---
+
+## Impact on Existing System
+
+### PROCESS.md
+
+A new section is added. No existing sections are modified. The new section references existing statuses and follows established conventions.
+
+### `close-reopen.sh`
+
+One new optional parameter (`--target-status`) is added. The existing `--issue` and `--action` parameters are unchanged. The script's behavior without `--target-status` is identical to current behavior.
+
+### Board Scanner
+
+No changes. The scanner already dispatches by status value. Reopened issues at valid statuses are handled identically to newly created issues at those statuses.
+
+### Status Field
+
+No new status options are added. The reopen workflow reuses existing statuses (`eng:po:triage`, `eng:bug:investigate`, `eng:dev:implement`, `eng:qe:test-design`, `eng:bug:in-progress`).
+
+### Comment History
+
+Reopened issues accumulate additional comments. The reopen attribution comment provides a clear timeline marker. No existing comments are modified or deleted.
+
+### Behavioral Changes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Issue at `done` needs rework | No defined process; ad-hoc | Defined reopen flow with target status and attribution |
+| `close-reopen.sh --action reopen` | Reopens issue only | Reopens issue only (unchanged) |
+| `close-reopen.sh --action reopen --target-status X` | N/A (parameter not supported) | Reopens issue and sets status to X |
+| Board scan finds reopened issue at `eng:dev:implement` | Dispatches normally | Dispatches normally (unchanged) |
+
+### Blast Radius
+
+| Change | Files | Nature |
+|--------|-------|--------|
+| PROCESS.md update | 1 file | Documentation — new section |
+| `close-reopen.sh` extension | 1 file | Additive — new optional parameter |
+
+No interface changes to other scripts, no new dependencies, no configuration changes.
+
+---
+
+## Security Considerations
+
+### Access Control
+
+The reopen operation uses existing GitHub permissions. Only users with write access to the repository can reopen issues and modify project board fields. No new permissions are required.
+
+### Audit Trail
+
+The mandatory reopen attribution comment provides an audit trail for why an issue was reopened, who reopened it, and what the target status is. This is append-only — existing comments are never modified.
+
+### No New Attack Surface
+
+- No new API endpoints or scripts (only an extension to an existing script)
+- No new configuration inputs beyond the existing status field values
+- No credential handling changes
+- The `--target-status` parameter is validated against existing status options; arbitrary values are rejected by the GitHub Projects API

--- a/projects/hypershift/knowledge/designs/epic-2.md
+++ b/projects/hypershift/knowledge/designs/epic-2.md
@@ -60,15 +60,110 @@ GetControlPlaneOperatorImage()
              Calls ExtractImageFiles(image="acr.io/...") -> SUCCESS
 ```
 
+### Systemic Gap Analysis
+
+Implementation audit revealed that the `RegistryMirrorProviderDecorator.Lookup()` fix alone is **necessary but not sufficient** for the AKS + nightly scenario. The `--registry-overrides` mechanism has gaps across multiple code paths. These gaps do NOT affect ICSP/IDMS because that mechanism was designed later (April 2023 vs. November 2021) with correct override-before-access patterns from the start.
+
+#### Why ICSP/IDMS Is Not Affected
+
+The two override mechanisms are wired differently:
+
+- **ICSP/IDMS** was built as a **two-pronged mechanism**: (1) `ProviderWithOpenShiftImageRegistryOverridesDecorator.Lookup()` applies overrides to the image *before* delegating in the release info path, and (2) `RegistryClientImageMetadataProvider` has its own `OpenShiftImageRegistryOverrides` field with every method calling `SeekOverride()` before registry access.
+
+- **`--registry-overrides`** was only built into the release info path via `RegistryMirrorProviderDecorator`, and even there it was applied *after* the delegate call (to tags only). It was **never added** to `RegistryClientImageMetadataProvider`. Three components (CPO, HCCO, karpenter-operator) noticed this gap and worked around it by merging `--registry-overrides` values into the ICSP/IDMS-style `map[string][]string` — effectively abandoning the native mechanism and piggybacking on the ICSP/IDMS path. But this workaround only covers scenarios where ICSP/IDMS infrastructure is available.
+
+#### Finding 1: `DetermineHostedClusterPayloadArch` — FATAL
+
+**File:** `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:1213`
+
+`DetermineHostedClusterPayloadArch` calls `registryclient.IsMultiArchManifestList(ctx, hc.Spec.Release.Image, ...)` which passes the raw image through `RegistryClientImageMetadataProvider.GetManifest()`. This calls `SeekOverride()` for ICSP/IDMS but has no mechanism for `--registry-overrides`. On failure, the reconciler sets `ValidReleaseImage=False` and **returns the error** (line 1224), halting reconciliation entirely. **This blocks cluster creation before the `GetControlPlaneOperatorImage` fix is even reached.**
+
+- **ICSP/IDMS:** Protected — `GetManifest()` calls `SeekOverride()` at `imagemetadata.go:262`
+- **`--registry-overrides`:** Broken — `RegistryClientImageMetadataProvider` has no field for it
+
+#### Finding 2: `GetDigest` for Progressing Condition — Operationally Fatal
+
+**File:** `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:1243`
+
+`registryClientImageMetadataProvider.GetDigest(ctx, hcluster.Spec.Release.Image, pullSecretBytes)` passes the raw image. When this fails, the Progressing condition is set to `Reason: Blocked` permanently — monitoring alerts fire, upgrade orchestration stalls.
+
+- **ICSP/IDMS:** Protected — `GetDigest()` calls `SeekOverride()` at `imagemetadata.go:216`
+- **`--registry-overrides`:** Broken — same root cause as Finding 1
+
+#### Finding 3: Karpenter Controller — FATAL (Neither Mechanism)
+
+**File:** `karpenter-operator/main.go:130`
+
+`ReleaseProvider: &releaseinfo.RegistryClientProvider{}` — a bare provider with **zero decorators**. Neither ICSP/IDMS nor `--registry-overrides` are applied. The `--registry-overrides` flag IS accepted (line 67) but never wired to this provider.
+
+- **ICSP/IDMS:** Also broken — no decorator chain at all
+- **`--registry-overrides`:** Broken — no decorator chain at all
+
+#### Finding 4: Karpenter Ignition Controller — Broken Natively
+
+**File:** `karpenter-operator/main.go:161-172`
+
+The decorator chain has `RegistryOverrides: nil` on the inner `RegistryMirrorProviderDecorator`. The `--registry-overrides` flag values are merged into `imageRegistryOverrides` (the ICSP/IDMS-style `map[string][]string`, lines 154-159) instead of being wired to the inner decorator. This means `--registry-overrides` only works through the ICSP/IDMS path (outer decorator with mirror probing semantics), not through the native string-replacement path.
+
+- **ICSP/IDMS:** Protected — outer decorator applies overrides including the merged flag values
+- **`--registry-overrides`:** Broken natively — inner decorator receives `nil`, flag values are rerouted through ICSP/IDMS semantics
+
+#### Finding 5: `RegistryClientImageMetadataProvider` — Systemic Root Cause
+
+**File:** `support/util/imagemetadata.go:115-119`
+
+The struct has `OpenShiftImageRegistryOverrides map[string][]string` but **no field for `--registry-overrides`** (`map[string]string`). Every method (`ImageMetadata`, `GetOverride`, `GetDigest`, `GetManifest`, `GetMetadata`) calls `SeekOverride()` which only processes ICSP/IDMS entries. This is the root cause of Findings 1 and 2 — any caller that resolves images through the metadata provider bypasses `--registry-overrides` entirely.
+
+- **ICSP/IDMS:** Protected by design — every method calls `SeekOverride()`
+- **`--registry-overrides`:** Not supported at all
+
+#### Impact Matrix
+
+| Code Path | Component | `--registry-overrides` | ICSP/IDMS | Severity |
+|-----------|-----------|----------------------|-----------|----------|
+| `Lookup()` (release info) | HO HC Reconciler | **Fixed** (decorator fix) | Works | Resolved |
+| `DetermineHostedClusterPayloadArch` | HO HC Reconciler | **Broken** — no metadata support | Works | FATAL — blocks before fix is reached |
+| `GetDigest` for Progressing | HO HC Reconciler | **Broken** — no metadata support | Works | Operationally fatal |
+| Karpenter controller `Lookup` | Karpenter Operator | **Broken** — bare provider | **Also broken** | FATAL |
+| Karpenter ignition `Lookup` | Karpenter Operator | Broken natively (`nil`) | Works (via workaround) | Broken on non-OpenShift |
+| NodePool reconciler (all paths) | HO NodePool Reconciler | Works | Works | OK |
+| CPO `cpReleaseProvider` | CPO | Works | Works | OK |
+| CPO `userReleaseProvider` | CPO | `nil` (intentional) | Works | OK (by design) |
+| Ignition server | Ignition Server | Works | Works | OK |
+
 ---
 
 ## Components and Interfaces
 
-### Modified Component
+### Modified Components
 
-**`RegistryMirrorProviderDecorator.Lookup()`** — `support/releaseinfo/registry_mirror_provider.go:26-46`
+#### Fix 1: `RegistryMirrorProviderDecorator.Lookup()` — `support/releaseinfo/registry_mirror_provider.go:26-46`
 
-This is the only function that needs modification. The fix applies `RegistryOverrides` string replacement to the `image` parameter **before** calling `p.Delegate.Lookup()`, in addition to the existing post-processing of component image tags.
+Apply `RegistryOverrides` string replacement to the `image` parameter **before** calling `p.Delegate.Lookup()`, in addition to the existing post-processing of component image tags.
+
+#### Fix 2: `RegistryClientImageMetadataProvider` — `support/util/imagemetadata.go:115-119`
+
+Add a `RegistryOverrides map[string]string` field. Apply simple string replacement to the image reference **before** calling `SeekOverride()` in each method (`ImageMetadata`, `GetOverride`, `GetDigest`, `GetManifest`, `GetMetadata`). This ensures `--registry-overrides` is applied in the image metadata path, resolving Findings 1 and 2.
+
+#### Fix 3: Karpenter controller wiring — `karpenter-operator/main.go:127-131`
+
+Replace the bare `&releaseinfo.RegistryClientProvider{}` with the full decorator chain, matching the pattern already used for the karpenter ignition controller at lines 161-172. This resolves Finding 3.
+
+#### Fix 4: Karpenter ignition controller wiring — `karpenter-operator/main.go:169`
+
+Wire `registryOverrides` to `RegistryMirrorProviderDecorator.RegistryOverrides` instead of (or in addition to) merging into the ICSP/IDMS map. This resolves Finding 4.
+
+#### Fix 5: `RegistryClientImageMetadataProvider` wiring — all instantiation sites
+
+Pass `registryOverrides` to the new `RegistryOverrides` field on `RegistryClientImageMetadataProvider` at each instantiation site:
+
+| Site | File | Current | Fix |
+|------|------|---------|-----|
+| HO | `support/globalconfig/imagecontentsource.go:251` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
+| Karpenter | `karpenter-operator/main.go:174` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
+| CPO | `control-plane-operator/main.go:479` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
+| HCCO | `hostedclusterconfigoperator/cmd.go:277` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
+| Ignition server | `ignition-server/cmd/start.go:155` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
 
 ### Interface Contracts (Unchanged)
 
@@ -89,14 +184,14 @@ All callers using the full decorator chain benefit from the fix transparently:
 | HAProxy reconciler | `haproxy.go:66` | Full decorator chain |
 | HostedClusterSizing reconciler | `hostedclustersizing_controller.go:76` | Full decorator chain |
 
-### Direct `RegistryClientProvider` Usages (Same Bug Class — Out of Scope)
+### Direct `RegistryClientProvider` Usages
 
-The following callers instantiate `RegistryClientProvider` directly, bypassing the decorator chain entirely. They suffer from the same class of bug (no registry overrides applied) but are out of scope for this epic, which targets the decorator chain fix.
+The following callers instantiate `RegistryClientProvider` directly, bypassing the decorator chain entirely.
 
 | Caller | File | Risk | Scope Decision |
 |--------|------|------|----------------|
-| karpenter-operator Reconciler | `karpenter-operator/main.go:130` | **Production** — same bug on nightly releases | Out of scope — follow-up issue required |
-| `hypershift create nodepool` CLI | `cmd/nodepool/core/create.go:82` | **Production** — CLI validation path | Out of scope — follow-up issue required |
+| karpenter-operator Reconciler | `karpenter-operator/main.go:130` | **Production** — same bug on nightly releases | **In scope** — Fix 3 wraps in decorator chain |
+| `hypershift create nodepool` CLI | `cmd/nodepool/core/create.go:82` | **Production** — CLI validation path | Out of scope — follow-up issue |
 | NodePool upgrade E2E test | `test/e2e/nodepool_upgrade_test.go:166` | Low — test infra | Out of scope |
 | Karpenter E2E test | `test/e2e/karpenter_test.go:481` | Low — test infra | Out of scope |
 | Karpenter CP upgrade E2E test | `test/e2e/karpenter_control_plane_upgrade_test.go:56` | Low — test infra | Out of scope |
@@ -104,8 +199,6 @@ The following callers instantiate `RegistryClientProvider` directly, bypassing t
 | E2E util | `test/e2e/util/util.go:3936` | Low — test infra | Out of scope |
 
 **Note:** The karpenter-operator file has *two* `RegistryClientProvider` usages — line 130 (direct, no decorators) and line 165 (properly wrapped in the full chain). Only the direct usage at line 130 is affected.
-
-**Follow-up:** A separate issue should be filed to wrap the two production-path direct usages (`karpenter-operator/main.go:130` and `cmd/nodepool/core/create.go:82`) in the decorator chain. The E2E test usages are lower priority as they run in controlled environments with direct registry access.
 
 ### Reference: Existing Override Pattern
 
@@ -200,19 +293,57 @@ With the override applied, the registry client connects to the mirror registry (
 **When** an override matches and the image reference is rewritten before delegation
 **Then** an INFO-level log line is emitted showing the original image and the overridden image, matching the logging pattern established by `ProviderWithOpenShiftImageRegistryOverridesDecorator` (which logs at `registry_image_content_policies.go:42`)
 
+### AC8: Image metadata path supports `--registry-overrides`
+
+**Given** `RegistryClientImageMetadataProvider` configured with `--registry-overrides` mapping `quay.io/openshift-release-dev/ocp-release-nightly` to an accessible mirror
+**When** `ImageMetadata()`, `GetDigest()`, or `GetManifest()` is called with a nightly release image
+**Then** the override is applied to the image reference before registry access, and the call succeeds against the mirror
+
+### AC9: `DetermineHostedClusterPayloadArch` succeeds on non-OpenShift clusters
+
+**Given** a non-OpenShift management cluster with `--registry-overrides` configured for nightly images
+**When** a HostedCluster is created with a nightly OCP release
+**Then** `DetermineHostedClusterPayloadArch` resolves the payload architecture successfully without `ValidReleaseImage=False`
+
+### AC10: Karpenter controller uses decorator chain
+
+**Given** the karpenter-operator configured with `--registry-overrides`
+**When** the karpenter controller reconciles a HostedControlPlane with a nightly release
+**Then** the `ReleaseProvider.Lookup()` call applies registry overrides (not bare `RegistryClientProvider`)
+
+### AC11: Karpenter ignition controller wires `--registry-overrides` natively
+
+**Given** the karpenter-operator configured with `--registry-overrides`
+**When** the karpenter ignition controller processes a release image lookup
+**Then** `RegistryMirrorProviderDecorator.RegistryOverrides` is populated (not `nil`) and overrides are applied via native string replacement
+
 ---
 
 ## Impact on Existing System
 
-### Minimal Blast Radius
+### Blast Radius
 
-The change is confined to a single function: `RegistryMirrorProviderDecorator.Lookup()` in `support/releaseinfo/registry_mirror_provider.go`. No interface changes, no new dependencies, no configuration changes.
+The changes span two support packages and three wiring sites:
+
+| Change | Files | Nature |
+|--------|-------|--------|
+| Fix 1: `RegistryMirrorProviderDecorator.Lookup()` | 1 file | Behavioral — apply override before delegation |
+| Fix 2: `RegistryClientImageMetadataProvider` | 1 file | Structural — add `RegistryOverrides` field, apply in 5 methods |
+| Fix 3: Karpenter controller wiring | 1 file | Wiring — replace bare provider with decorator chain |
+| Fix 4: Karpenter ignition wiring | 1 file | Wiring — populate `RegistryOverrides` field |
+| Fix 5: Metadata provider wiring | 5 files | Wiring — pass `registryOverrides` to metadata provider |
+
+No interface changes, no new dependencies, no configuration changes. The `RegistryClientImageMetadataProvider` struct gains one new field — existing callers that don't set it get the zero value (`nil`), preserving current behavior.
 
 ### Behavioral Changes
 
 | Scenario | Before | After |
 |----------|--------|-------|
 | Nightly release + `--registry-overrides` + non-OpenShift cluster | **FAILS** — pulls from original registry | **WORKS** — pulls from mirror |
+| Payload arch detection + `--registry-overrides` + non-OpenShift | **FAILS** — `ValidReleaseImage=False`, reconciliation halted | **WORKS** — metadata provider applies override |
+| GetDigest for Progressing + `--registry-overrides` + non-OpenShift | **FAILS** — stuck Progressing condition | **WORKS** — metadata provider applies override |
+| Karpenter controller + any override config | **FAILS** — bare provider, no overrides | **WORKS** — full decorator chain |
+| Karpenter ignition + `--registry-overrides` (native path) | **BROKEN** — `RegistryOverrides: nil` | **WORKS** — field populated |
 | GA release + `--registry-overrides` (no matching entry) | Works (public access) | Works (unchanged — no override match) |
 | Any release + ICSP/IDMS on OpenShift cluster | Works (outer decorator handles) | Works (unchanged — outer decorator runs first) |
 | Any release + no overrides configured | Works | Works (unchanged — empty map, no replacements) |
@@ -246,11 +377,15 @@ This is a **pre-existing limitation** — the same non-determinism exists in the
 
 **No mitigation in this epic.** If this needs to be addressed, it should be a separate effort that sorts map keys by specificity (longest prefix first) across both code paths.
 
-### Known limitation: Direct `RegistryClientProvider` usages
+### Known limitation: CLI `nodepool create` bare provider
 
-Seven call sites instantiate `RegistryClientProvider` directly, bypassing the decorator chain (see "Direct `RegistryClientProvider` Usages" table in Components and Interfaces). Two are production code paths (`karpenter-operator/main.go:130` and `cmd/nodepool/core/create.go:82`) with the same class of bug. These are **explicitly out of scope** for this epic.
+`cmd/nodepool/core/create.go:82` instantiates `RegistryClientProvider` directly for version compatibility checking. This is a lower-priority production path (CLI validation, not reconciler hot path) and is **out of scope** for this epic.
 
-**Mitigation:** A follow-up issue will be filed to wrap the two production-path direct usages in the decorator chain after this fix lands.
+**Mitigation:** A follow-up issue will be filed to wrap this usage in the decorator chain.
+
+### Known limitation: E2E test bare providers
+
+Five E2E test files instantiate `RegistryClientProvider` directly. These run in controlled environments with direct registry access and are **out of scope**.
 
 ---
 
@@ -274,3 +409,42 @@ The override only replaces the registry portion of the image reference. The imag
 - No new configuration inputs — uses the existing `--registry-overrides` flag
 - No new permissions required — the mirror registry credentials should already be in the pull secret
 - No credential leakage — pull secrets are not logged or exposed differently
+
+---
+
+## Follow-up: Unified Registry Override Abstraction
+
+This epic fixes the immediate gaps with targeted patches. A follow-up epic should design a **unified override abstraction** to eliminate this class of bugs permanently.
+
+### Problem Statement
+
+Today there are two independent override mechanisms with different data structures, semantics, and coverage:
+
+| | `--registry-overrides` | ICSP/IDMS |
+|---|---|---|
+| Data structure | `map[string]string` | `map[string][]string` |
+| Semantics | Simple `strings.Replace` | Ordered mirror list, availability probing, caching, fallback |
+| Release info path | `RegistryMirrorProviderDecorator` (inner decorator) | `ProviderWithOpenShiftImageRegistryOverridesDecorator` (outer decorator) |
+| Image metadata path | **Not supported** (fixed by this epic, but bolted-on) | Native via `SeekOverride()` |
+| Introduced | November 2021 | April 2023 |
+
+Six separate wiring sites manually construct the decorator chain (HO, CPO `cpReleaseProvider`, CPO `userReleaseProvider`, HCCO, ignition-server, karpenter-operator). Three of these (CPO, HCCO, karpenter) merge `--registry-overrides` into the ICSP/IDMS map as a workaround for the missing native support — effectively abandoning the original mechanism's semantics.
+
+### Why Unification Matters
+
+- Every new image resolution code path must remember to wire **both** mechanisms, or it silently breaks on non-OpenShift clusters
+- The merge-into-ICSP/IDMS workaround changes `--registry-overrides` semantics (adds mirror probing, 15s timeouts, availability caching) which operators may not expect
+- The dual-decorator chain is hard to reason about — the interaction between outer and inner overrides is non-obvious
+- The OLM catalogs have a **third** override entry point (via HCP annotation) that follows yet another pattern
+
+### Scope for Follow-up Design
+
+The follow-up design session should evaluate:
+
+1. Whether to unify into a single abstraction or keep the mechanisms separate with consistent coverage
+2. How to handle the semantic differences (simple replacement vs. mirror probing with fallback)
+3. The serialization/deserialization round-trip through env vars and CLI flags across HO -> CPO -> HCCO -> ignition-server
+4. Impact on the 6 wiring sites, 2 decorator types, mock/test infrastructure, and the OLM catalog path
+5. Whether to split across multiple upstream PRs or land as one refactor
+
+This should be its own epic with a dedicated design session — it is architecturally significant and touches 5 binaries across ~15 files.

--- a/projects/hypershift/knowledge/designs/epic-2.md
+++ b/projects/hypershift/knowledge/designs/epic-2.md
@@ -80,14 +80,32 @@ This is the only function that needs modification. The fix applies `RegistryOver
 
 ### Affected Callers (No Changes Required)
 
-All callers pass the full decorator chain, so the fix is transparent:
+All callers using the full decorator chain benefit from the fix transparently:
 
 | Caller | File | Provider Type |
 |--------|------|---------------|
-| HostedClusterReconciler | `hostedcluster_controller.go:672` | Has overrides |
-| NodePoolReconciler | `nodepool_controller.go:980` | Has overrides |
-| HAProxy reconciler | `haproxy.go:66` | Has overrides |
-| HostedClusterSizing reconciler | `hostedclustersizing_controller.go:76` | Has overrides |
+| HostedClusterReconciler | `hostedcluster_controller.go:672` | Full decorator chain |
+| NodePoolReconciler | `nodepool_controller.go:980` | Full decorator chain |
+| HAProxy reconciler | `haproxy.go:66` | Full decorator chain |
+| HostedClusterSizing reconciler | `hostedclustersizing_controller.go:76` | Full decorator chain |
+
+### Direct `RegistryClientProvider` Usages (Same Bug Class — Out of Scope)
+
+The following callers instantiate `RegistryClientProvider` directly, bypassing the decorator chain entirely. They suffer from the same class of bug (no registry overrides applied) but are out of scope for this epic, which targets the decorator chain fix.
+
+| Caller | File | Risk | Scope Decision |
+|--------|------|------|----------------|
+| karpenter-operator Reconciler | `karpenter-operator/main.go:130` | **Production** — same bug on nightly releases | Out of scope — follow-up issue required |
+| `hypershift create nodepool` CLI | `cmd/nodepool/core/create.go:82` | **Production** — CLI validation path | Out of scope — follow-up issue required |
+| NodePool upgrade E2E test | `test/e2e/nodepool_upgrade_test.go:166` | Low — test infra | Out of scope |
+| Karpenter E2E test | `test/e2e/karpenter_test.go:481` | Low — test infra | Out of scope |
+| Karpenter CP upgrade E2E test | `test/e2e/karpenter_control_plane_upgrade_test.go:56` | Low — test infra | Out of scope |
+| E2E version util | `test/e2e/util/version.go:55` | Low — test infra | Out of scope |
+| E2E util | `test/e2e/util/util.go:3936` | Low — test infra | Out of scope |
+
+**Note:** The karpenter-operator file has *two* `RegistryClientProvider` usages — line 130 (direct, no decorators) and line 165 (properly wrapped in the full chain). Only the direct usage at line 130 is affected.
+
+**Follow-up:** A separate issue should be filed to wrap the two production-path direct usages (`karpenter-operator/main.go:130` and `cmd/nodepool/core/create.go:82`) in the decorator chain. The E2E test usages are lower priority as they run in controlled environments with direct registry access.
 
 ### Reference: Existing Override Pattern
 
@@ -126,7 +144,7 @@ With the override applied, the registry client connects to the mirror registry (
 ### Edge Cases
 
 1. **No matching override:** If no `RegistryOverrides` entry matches the image, the original image is passed unmodified — preserving current behavior for GA releases and configurations without overrides.
-2. **Multiple matching overrides:** `strings.Replace` with count=1 ensures only the first match is replaced per override entry. The `for` loop over `RegistryOverrides` applies all matching entries sequentially — same behavior as the existing tag post-processing.
+2. **Multiple matching overrides:** `strings.Replace` with count=1 ensures only the first match is replaced per override entry. The `for` loop iterates over a Go `map[string]string`, so iteration order is non-deterministic. If two entries both match (e.g., `quay.io` and `quay.io/openshift-release-dev`), the result may vary between runs. This is a **known limitation**, pre-existing in the tag post-processing path, and is inherited unchanged by the fix. See the Risks and Known Limitations section.
 3. **Cache key consistency:** The `CachedProvider` caches by the image string it receives. After the fix, the cache key will be the **overridden** image URL. This is correct — the same mirrored image should return the same cached result. Different mirror targets will produce different cache entries, which is also correct.
 
 ---
@@ -160,13 +178,14 @@ With the override applied, the registry client connects to the mirror registry (
 
 ### AC5: Unit test coverage
 
-**Given** the modified `RegistryMirrorProviderDecorator.Lookup()` function
-**When** unit tests are executed
-**Then** tests verify:
+**Given** `RegistryMirrorProviderDecorator` currently has **zero unit test coverage** (the only test that instantiates it, `TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup`, passes empty `RegistryOverrides` and never exercises the override logic)
+**When** the fix is implemented
+**Then** new unit tests MUST land **with** the fix (not as follow-up), covering:
 - Override is applied to the image passed to the delegate
 - Override is NOT applied when no matching entry exists
 - Component tag post-processing still works
 - Multiple overrides are applied correctly
+- Delegate receives the overridden image (not the original)
 
 ### AC6: ICSP/IDMS decorator interaction preserved
 
@@ -174,6 +193,12 @@ With the override applied, the registry client connects to the mirror registry (
 **And** `--registry-overrides` also configured
 **When** the decorator chain processes a release image lookup
 **Then** ICSP/IDMS overrides are attempted first (outer decorator), and `--registry-overrides` are applied to the image before the inner delegate call — both layers work together without conflict
+
+### AC7: INFO-level logging on override application
+
+**Given** a `RegistryMirrorProviderDecorator` configured with `--registry-overrides`
+**When** an override matches and the image reference is rewritten before delegation
+**Then** an INFO-level log line is emitted showing the original image and the overridden image, matching the logging pattern established by `ProviderWithOpenShiftImageRegistryOverridesDecorator` (which logs at `registry_image_content_policies.go:42`)
 
 ---
 
@@ -197,9 +222,35 @@ The change is confined to a single function: `RegistryMirrorProviderDecorator.Lo
 
 The `CachedProvider` sits below `RegistryMirrorProviderDecorator` in the chain. After the fix, the cache key changes from the original image URL to the overridden image URL. This is correct and desirable — it ensures cache entries match what was actually fetched. There is no risk of stale cache entries because the cache is populated per-process (in-memory map).
 
+**Cache fragmentation under dual-decorator configs:** When both ICSP/IDMS (outer decorator) and `--registry-overrides` (inner decorator) are configured, the same logical image can be cached under different keys depending on which decorator path resolves it. For example, the outer decorator may rewrite `quay.io/foo` to `mirror-a.example.com/foo`, while the inner decorator would rewrite it to `mirror-b.example.com/foo`. This produces two cache entries for the same logical content. This is **harmless** — content is digest-pinned (so both entries are identical), the cache is in-memory with a 30-minute TTL, and the extra entry is a negligible memory cost. No mitigation is needed.
+
 ### Provider Chain Order
 
 The fix does not change the provider chain order. `ProviderWithOpenShiftImageRegistryOverridesDecorator` (outer) still runs first, attempting ICSP/IDMS mirrors. If those fail or are not configured, it delegates to `RegistryMirrorProviderDecorator` (inner), which now applies `--registry-overrides` to both the lookup image and the result tags. The two override mechanisms are complementary and non-conflicting.
+
+---
+
+## Risks and Known Limitations
+
+### Risk: Zero existing test coverage
+
+`RegistryMirrorProviderDecorator` has **no unit tests** today. The only test that instantiates it (`TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup` in `registry_image_content_policies_test.go:25`) passes empty `RegistryOverrides` and never exercises the override logic. This means the fix modifies untested code.
+
+**Mitigation:** Unit tests MUST land with the fix, not as follow-up. AC5 explicitly mandates this.
+
+### Known limitation: Overlapping override non-determinism
+
+Go `map` iteration order is non-deterministic. If `RegistryOverrides` contains two entries that both match the same image (e.g., `quay.io` and `quay.io/openshift-release-dev`), the result varies between runs because `strings.Replace` is applied in arbitrary order.
+
+This is a **pre-existing limitation** — the same non-determinism exists in the current tag post-processing loop (lines 36-39 of `registry_mirror_provider.go`). The fix inherits this behavior; it does not introduce new non-determinism. In practice, operators configure non-overlapping override entries (one source prefix per mirror), so this is unlikely to manifest.
+
+**No mitigation in this epic.** If this needs to be addressed, it should be a separate effort that sorts map keys by specificity (longest prefix first) across both code paths.
+
+### Known limitation: Direct `RegistryClientProvider` usages
+
+Seven call sites instantiate `RegistryClientProvider` directly, bypassing the decorator chain (see "Direct `RegistryClientProvider` Usages" table in Components and Interfaces). Two are production code paths (`karpenter-operator/main.go:130` and `cmd/nodepool/core/create.go:82`) with the same class of bug. These are **explicitly out of scope** for this epic.
+
+**Mitigation:** A follow-up issue will be filed to wrap the two production-path direct usages in the decorator chain after this fix lands.
 
 ---
 

--- a/projects/hypershift/knowledge/designs/epic-2.md
+++ b/projects/hypershift/knowledge/designs/epic-2.md
@@ -1,0 +1,225 @@
+# Design: Fix Registry Override Not Applied When Extracting Release Metadata
+
+**Epic:** #2 — Fix registry override not applied when extracting release metadata on non-OpenShift management clusters
+**Upstream bug:** OCPBUGS-83564
+**Date:** 2026-04-17
+
+---
+
+## Overview
+
+On non-OpenShift management clusters (e.g., AKS in ARO-HCP), hosted cluster creation fails when using nightly OCP releases with `--registry-overrides` configured. The `RegistryMirrorProviderDecorator` applies registry overrides only to **component image tags** inside the returned `ImageStream`, but does **not** apply them to the **release image pullspec** before calling the delegate provider. This causes the system to query the original registry (`quay.io`) instead of the configured mirror (e.g., ACR), resulting in an `unauthorized` error for nightly releases that require authentication.
+
+GA releases work because `quay.io/openshift-release-dev/ocp-release` is publicly accessible. Nightly releases (`ocp-release-nightly`) require authentication, exposing the bug.
+
+---
+
+## Architecture
+
+### Current Provider Chain
+
+The release provider is a decorator chain constructed in `NewCommonRegistryProvider` (`support/globalconfig/imagecontentsource.go:226-261`):
+
+```
+ProviderWithOpenShiftImageRegistryOverridesDecorator     (ICSP/IDMS mirrors)
+  -> RegistryMirrorProviderDecorator                     (--registry-overrides flag)
+       -> CachedProvider
+            -> RegistryClientProvider                    (actual registry pull)
+```
+
+### Current Call Flow (Broken)
+
+```
+GetControlPlaneOperatorImage()                           [support/util/util.go:667]
+  -> releaseProvider.Lookup(image="quay.io/.../ocp-release-nightly@sha256:...")
+    -> ProviderWithOpenShiftImageRegistryOverridesDecorator.Lookup()
+       [registry_image_content_policies.go:23]
+       OpenShiftImageRegistryOverrides is nil on non-OpenShift -> falls through
+      -> RegistryMirrorProviderDecorator.Lookup()
+         [registry_mirror_provider.go:26]
+         Calls Delegate.Lookup(image) with ORIGINAL image   <-- BUG
+         Only post-processes component tags in returned ImageStream
+        -> CachedProvider.Lookup()
+          -> RegistryClientProvider.Lookup()
+             [registryclient_provider.go:22]
+             Calls ExtractImageFiles(image="quay.io/...") -> UNAUTHORIZED
+```
+
+### Fixed Call Flow
+
+```
+GetControlPlaneOperatorImage()
+  -> releaseProvider.Lookup(image="quay.io/.../ocp-release-nightly@sha256:...")
+    -> ProviderWithOpenShiftImageRegistryOverridesDecorator.Lookup()
+       [no-op on non-OpenShift]
+      -> RegistryMirrorProviderDecorator.Lookup()
+         Applies RegistryOverrides to image BEFORE delegating  <-- FIX
+         Calls Delegate.Lookup(lookupImage="acr.io/...@sha256:...")
+        -> CachedProvider.Lookup()
+          -> RegistryClientProvider.Lookup()
+             Calls ExtractImageFiles(image="acr.io/...") -> SUCCESS
+```
+
+---
+
+## Components and Interfaces
+
+### Modified Component
+
+**`RegistryMirrorProviderDecorator.Lookup()`** — `support/releaseinfo/registry_mirror_provider.go:26-46`
+
+This is the only function that needs modification. The fix applies `RegistryOverrides` string replacement to the `image` parameter **before** calling `p.Delegate.Lookup()`, in addition to the existing post-processing of component image tags.
+
+### Interface Contracts (Unchanged)
+
+| Interface | File | Change |
+|-----------|------|--------|
+| `Provider` | `support/releaseinfo/releaseinfo.go` | No change |
+| `ProviderWithRegistryOverrides` | `support/releaseinfo/releaseinfo.go` | No change |
+| `ProviderWithOpenShiftImageRegistryOverrides` | `support/releaseinfo/releaseinfo.go` | No change |
+
+### Affected Callers (No Changes Required)
+
+All callers pass the full decorator chain, so the fix is transparent:
+
+| Caller | File | Provider Type |
+|--------|------|---------------|
+| HostedClusterReconciler | `hostedcluster_controller.go:672` | Has overrides |
+| NodePoolReconciler | `nodepool_controller.go:980` | Has overrides |
+| HAProxy reconciler | `haproxy.go:66` | Has overrides |
+| HostedClusterSizing reconciler | `hostedclustersizing_controller.go:76` | Has overrides |
+
+### Reference: Existing Override Pattern
+
+`ProviderWithOpenShiftImageRegistryOverridesDecorator.Lookup()` (`registry_image_content_policies.go:23-54`) already applies a similar pattern for ICSP/IDMS overrides — it replaces the `image` string before calling `p.Delegate.Lookup()`. The fix aligns `RegistryMirrorProviderDecorator` with this established pattern.
+
+Similarly, `RegistryClientImageMetadataProvider.ImageMetadata()` (`support/util/imagemetadata.go:131-168`) correctly uses `SeekOverride()` to apply ICSP/IDMS overrides before accessing the registry. The release info path should behave consistently.
+
+---
+
+## Data Models
+
+No data model changes are required. The `RegistryOverrides` map (`map[string]string`) already contains the correct source-to-destination mappings. The fix only changes **when** these mappings are applied during the `Lookup` call.
+
+---
+
+## Error Handling
+
+### Current Behavior (Broken)
+
+When the override is not applied, `RegistryClientProvider.Lookup()` fails with:
+```
+failed to extract release metadata: failed to obtain root manifest for
+quay.io/openshift-release-dev/ocp-release-nightly@sha256:...
+unauthorized: access to the requested resource is not authorized
+```
+
+This error propagates up through `GetControlPlaneOperatorImage()` as:
+```
+failed to get controlPlaneOperatorImage: failed to extract release metadata: ...
+```
+
+### Fixed Behavior
+
+With the override applied, the registry client connects to the mirror registry (e.g., ACR) which has valid credentials configured, and the lookup succeeds. If the mirror also fails, the error message will now correctly reference the mirror URL rather than the original registry, making debugging easier.
+
+### Edge Cases
+
+1. **No matching override:** If no `RegistryOverrides` entry matches the image, the original image is passed unmodified — preserving current behavior for GA releases and configurations without overrides.
+2. **Multiple matching overrides:** `strings.Replace` with count=1 ensures only the first match is replaced per override entry. The `for` loop over `RegistryOverrides` applies all matching entries sequentially — same behavior as the existing tag post-processing.
+3. **Cache key consistency:** The `CachedProvider` caches by the image string it receives. After the fix, the cache key will be the **overridden** image URL. This is correct — the same mirrored image should return the same cached result. Different mirror targets will produce different cache entries, which is also correct.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Registry override applied to release image lookup
+
+**Given** a HyperShift operator configured with `--registry-overrides=quay.io/openshift-release-dev/ocp-release-nightly=mirror.example.com/openshift-release-dev/ocp-release-nightly`
+**When** a HostedCluster is created referencing a nightly release image `quay.io/openshift-release-dev/ocp-release-nightly@sha256:abc123`
+**Then** the release metadata extraction call uses `mirror.example.com/openshift-release-dev/ocp-release-nightly@sha256:abc123` instead of the original `quay.io` reference
+
+### AC2: Nightly releases work on non-OpenShift management clusters
+
+**Given** a non-OpenShift management cluster (e.g., AKS) with no ICSP/IDMS capability
+**And** `--registry-overrides` configured to map `quay.io` nightly images to an accessible mirror
+**When** a HostedCluster is created with a nightly OCP release
+**Then** the `controlPlaneOperatorImage` is successfully resolved without authorization errors
+
+### AC3: GA release behavior unchanged (no regression)
+
+**Given** a HyperShift operator with `--registry-overrides` configured for nightly images only
+**When** a HostedCluster is created with a GA release image (`quay.io/openshift-release-dev/ocp-release`)
+**Then** the release metadata extraction uses the original GA image reference (no override match) and succeeds as before
+
+### AC4: Component image tags still overridden
+
+**Given** a HyperShift operator with `--registry-overrides` configured
+**When** release metadata is successfully extracted
+**Then** the component image tags in the returned `ImageStream` still have registry overrides applied (existing post-processing behavior preserved)
+
+### AC5: Unit test coverage
+
+**Given** the modified `RegistryMirrorProviderDecorator.Lookup()` function
+**When** unit tests are executed
+**Then** tests verify:
+- Override is applied to the image passed to the delegate
+- Override is NOT applied when no matching entry exists
+- Component tag post-processing still works
+- Multiple overrides are applied correctly
+
+### AC6: ICSP/IDMS decorator interaction preserved
+
+**Given** an OpenShift management cluster with ICSP/IDMS configured
+**And** `--registry-overrides` also configured
+**When** the decorator chain processes a release image lookup
+**Then** ICSP/IDMS overrides are attempted first (outer decorator), and `--registry-overrides` are applied to the image before the inner delegate call — both layers work together without conflict
+
+---
+
+## Impact on Existing System
+
+### Minimal Blast Radius
+
+The change is confined to a single function: `RegistryMirrorProviderDecorator.Lookup()` in `support/releaseinfo/registry_mirror_provider.go`. No interface changes, no new dependencies, no configuration changes.
+
+### Behavioral Changes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Nightly release + `--registry-overrides` + non-OpenShift cluster | **FAILS** — pulls from original registry | **WORKS** — pulls from mirror |
+| GA release + `--registry-overrides` (no matching entry) | Works (public access) | Works (unchanged — no override match) |
+| Any release + ICSP/IDMS on OpenShift cluster | Works (outer decorator handles) | Works (unchanged — outer decorator runs first) |
+| Any release + no overrides configured | Works | Works (unchanged — empty map, no replacements) |
+| Component image tags in ImageStream | Overridden | Overridden (preserved) |
+
+### Cache Impact
+
+The `CachedProvider` sits below `RegistryMirrorProviderDecorator` in the chain. After the fix, the cache key changes from the original image URL to the overridden image URL. This is correct and desirable — it ensures cache entries match what was actually fetched. There is no risk of stale cache entries because the cache is populated per-process (in-memory map).
+
+### Provider Chain Order
+
+The fix does not change the provider chain order. `ProviderWithOpenShiftImageRegistryOverridesDecorator` (outer) still runs first, attempting ICSP/IDMS mirrors. If those fail or are not configured, it delegates to `RegistryMirrorProviderDecorator` (inner), which now applies `--registry-overrides` to both the lookup image and the result tags. The two override mechanisms are complementary and non-conflicting.
+
+---
+
+## Security Considerations
+
+### Pull Secret Handling
+
+The pull secret is passed through the provider chain unchanged. The fix does not alter how pull secrets are handled — they are forwarded to the registry client for authentication against whichever registry URL is used (original or overridden). No new credential exposure.
+
+### Registry Trust
+
+The `--registry-overrides` flag is an operator-level configuration set by the cluster administrator. The fix does not introduce new override sources — it applies the **already-configured** overrides to an additional code path where they were missing. The trust model is unchanged: the operator administrator controls which registries are trusted as mirrors.
+
+### Image Integrity
+
+The override only replaces the registry portion of the image reference. The image digest (`@sha256:...`) is preserved, ensuring that the mirrored image has the same content as the original. Image verification (if any) continues to work against the digest.
+
+### No New Attack Surface
+
+- No new network connections — the fix redirects an existing registry pull to a different (configured) destination
+- No new configuration inputs — uses the existing `--registry-overrides` flag
+- No new permissions required — the mirror registry credentials should already be in the pull secret
+- No credential leakage — pull secrets are not logged or exposed differently

--- a/projects/hypershift/knowledge/designs/epic-2.md
+++ b/projects/hypershift/knowledge/designs/epic-2.md
@@ -14,6 +14,49 @@ GA releases work because `quay.io/openshift-release-dev/ocp-release` is publicly
 
 ---
 
+## Phased Approach
+
+### Verified vs. Hypothesized
+
+Only one failure path is confirmed by the upstream bug report (OCPBUGS-83564): the `RegistryMirrorProviderDecorator.Lookup()` call in the HO's `GetControlPlaneOperatorImage` path. The extended code audit identified additional code paths that appear to have the same class of bug, but these have **not been reproduced** in a live environment. Some components (HCCO, karpenter, CPO) use a workaround — merging `--registry-overrides` into the ICSP/IDMS map — whose real-world sufficiency is unverified.
+
+Before expanding scope, we must reproduce each hypothesized failure on an actual AKS management cluster.
+
+### Phase 0: Reproduction on AKS
+
+**Goal:** Confirm which code paths actually fail on a non-OpenShift management cluster with `--registry-overrides` + nightly release.
+
+**Prerequisites:**
+1. Provision an AKS management cluster (no ICSP/IDMS capability)
+2. Set up an ACR mirror containing a nightly OCP release (`ocp-release-nightly`)
+3. Install HyperShift operator with `--registry-overrides=quay.io/openshift-release-dev/ocp-release-nightly=<acr-mirror>/openshift-release-dev/ocp-release-nightly`
+4. Configure a HostedCluster with matching `imageContentSources`
+
+**Reproduction matrix:**
+
+| # | Code Path | Component | What to observe | Expected failure (hypothesis) |
+|---|-----------|-----------|----------------|-------------------------------|
+| R1 | `GetControlPlaneOperatorImage` → `Lookup()` | HO HC Reconciler | HC condition `ValidReleaseImage` | `unauthorized` pulling from `quay.io` (confirmed by OCPBUGS-83564) |
+| R2 | `DetermineHostedClusterPayloadArch` → `GetManifest()` | HO HC Reconciler | HC condition `ValidReleaseImage=False`, reconciler halts | `unauthorized` — metadata provider has no `--registry-overrides` support |
+| R3 | `GetDigest` for Progressing condition | HO HC Reconciler | HC condition `Progressing=Blocked` permanently | `unauthorized` — metadata provider early-return path |
+| R4 | Karpenter controller `Lookup()` | Karpenter Operator | Karpenter reconciler error log | `unauthorized` — bare `RegistryClientProvider`, zero decorators |
+| R5 | Karpenter ignition controller `Lookup()` | Karpenter Operator | Ignition reconciler error log | Broken natively — `RegistryOverrides: nil`, outer decorator workaround may mask |
+| R6 | HCCO release provider `Lookup()` | HCCO | HCCO reconciler error log | Broken natively — `RegistryOverrides: nil` (same class as R5), outer decorator workaround may mask; HCCO is core production, always deployed |
+
+**Method:** For R1-R3, create a HostedCluster and observe the HO reconciler logs and HC conditions. R2 likely fires before R1 (arch detection runs first in the reconcile loop). For R4-R5, enable karpenter on the cluster. For R6, observe HCCO logs in the hosted control plane namespace.
+
+**Outcome:** Each row gets a status: **confirmed** (failure reproduced), **not affected** (workaround sufficient), or **blocked** (can't reach this path because an earlier path fails first). Confirmed paths get fixes; not-affected paths get documented; blocked paths get retested after earlier fixes land.
+
+### Phase 1: Confirmed Fix
+
+Fix 1 (`RegistryMirrorProviderDecorator.Lookup()`) is confirmed by OCPBUGS-83564 and is implemented (commit `c804b0c17`). This fix lands regardless of reproduction results.
+
+### Phase 2: Validated Fixes
+
+Fixes 2-6 are conditional on Phase 0 reproduction results. Each fix is applied only if its corresponding reproduction row is confirmed as a real failure. The design below specifies each fix so they are ready to implement once validated.
+
+---
+
 ## Architecture
 
 ### Current Provider Chain
@@ -60,9 +103,9 @@ GetControlPlaneOperatorImage()
              Calls ExtractImageFiles(image="acr.io/...") -> SUCCESS
 ```
 
-### Systemic Gap Analysis
+### Systemic Gap Analysis (Hypothesized — Pending Phase 0 Reproduction)
 
-Implementation audit revealed that the `RegistryMirrorProviderDecorator.Lookup()` fix alone is **necessary but not sufficient** for the AKS + nightly scenario. The `--registry-overrides` mechanism has gaps across multiple code paths. These gaps do NOT affect ICSP/IDMS because that mechanism was designed later (April 2023 vs. November 2021) with correct override-before-access patterns from the start.
+Code audit identified additional code paths that appear to have the same class of bug as the confirmed `Lookup()` fix. **None of these have been reproduced in a live environment.** Some components use a workaround (merging `--registry-overrides` into the ICSP/IDMS map) whose sufficiency in the AKS + nightly scenario is unverified. Each hypothesis maps to a reproduction row in Phase 0.
 
 #### Why ICSP/IDMS Is Not Affected
 
@@ -72,88 +115,187 @@ The two override mechanisms are wired differently:
 
 - **`--registry-overrides`** was only built into the release info path via `RegistryMirrorProviderDecorator`, and even there it was applied *after* the delegate call (to tags only). It was **never added** to `RegistryClientImageMetadataProvider`. Three components (CPO, HCCO, karpenter-operator) noticed this gap and worked around it by merging `--registry-overrides` values into the ICSP/IDMS-style `map[string][]string` — effectively abandoning the native mechanism and piggybacking on the ICSP/IDMS path. But this workaround only covers scenarios where ICSP/IDMS infrastructure is available.
 
-#### Finding 1: `DetermineHostedClusterPayloadArch` — FATAL
+#### Hypothesis 1: `DetermineHostedClusterPayloadArch` — Potentially FATAL (→ R2)
 
 **File:** `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:1213`
 
-`DetermineHostedClusterPayloadArch` calls `registryclient.IsMultiArchManifestList(ctx, hc.Spec.Release.Image, ...)` which passes the raw image through `RegistryClientImageMetadataProvider.GetManifest()`. This calls `SeekOverride()` for ICSP/IDMS but has no mechanism for `--registry-overrides`. On failure, the reconciler sets `ValidReleaseImage=False` and **returns the error** (line 1224), halting reconciliation entirely. **This blocks cluster creation before the `GetControlPlaneOperatorImage` fix is even reached.**
+`DetermineHostedClusterPayloadArch` calls `registryclient.IsMultiArchManifestList(ctx, hc.Spec.Release.Image, ...)` which passes the raw image through `RegistryClientImageMetadataProvider.GetManifest()`. This calls `SeekOverride()` for ICSP/IDMS but has no mechanism for `--registry-overrides`. On failure, the reconciler sets `ValidReleaseImage=False` and **returns the error** (line 1224), halting reconciliation entirely. **If confirmed, this blocks cluster creation before the `GetControlPlaneOperatorImage` fix is even reached.**
 
 - **ICSP/IDMS:** Protected — `GetManifest()` calls `SeekOverride()` at `imagemetadata.go:262`
-- **`--registry-overrides`:** Broken — `RegistryClientImageMetadataProvider` has no field for it
+- **`--registry-overrides`:** No support in `RegistryClientImageMetadataProvider`
+- **Reproduction:** R2 in Phase 0
 
-#### Finding 2: `GetDigest` for Progressing Condition — Operationally Fatal
+#### Hypothesis 2: `GetDigest` for Progressing Condition — Potentially Operationally Fatal (→ R3)
 
 **File:** `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go:1243`
 
 `registryClientImageMetadataProvider.GetDigest(ctx, hcluster.Spec.Release.Image, pullSecretBytes)` passes the raw image. When this fails, the Progressing condition is set to `Reason: Blocked` permanently — monitoring alerts fire, upgrade orchestration stalls.
 
 - **ICSP/IDMS:** Protected — `GetDigest()` calls `SeekOverride()` at `imagemetadata.go:216`
-- **`--registry-overrides`:** Broken — same root cause as Finding 1
+- **`--registry-overrides`:** No support — same root cause as Hypothesis 1
+- **Reproduction:** R3 in Phase 0
 
-#### Finding 3: Karpenter Controller — FATAL (Neither Mechanism)
+#### Hypothesis 3: Karpenter Controller — Potentially FATAL (→ R4)
 
 **File:** `karpenter-operator/main.go:130`
 
 `ReleaseProvider: &releaseinfo.RegistryClientProvider{}` — a bare provider with **zero decorators**. Neither ICSP/IDMS nor `--registry-overrides` are applied. The `--registry-overrides` flag IS accepted (line 67) but never wired to this provider.
 
-- **ICSP/IDMS:** Also broken — no decorator chain at all
-- **`--registry-overrides`:** Broken — no decorator chain at all
+- **ICSP/IDMS:** Also no support — no decorator chain at all
+- **`--registry-overrides`:** No support — no decorator chain at all
+- **Reproduction:** R4 in Phase 0
 
-#### Finding 4: Karpenter Ignition Controller — Broken Natively
+#### Hypothesis 4: Karpenter Ignition Controller — Unclear (→ R5)
 
 **File:** `karpenter-operator/main.go:161-172`
 
-The decorator chain has `RegistryOverrides: nil` on the inner `RegistryMirrorProviderDecorator`. The `--registry-overrides` flag values are merged into `imageRegistryOverrides` (the ICSP/IDMS-style `map[string][]string`, lines 154-159) instead of being wired to the inner decorator. This means `--registry-overrides` only works through the ICSP/IDMS path (outer decorator with mirror probing semantics), not through the native string-replacement path.
+The decorator chain has `RegistryOverrides: nil` on the inner `RegistryMirrorProviderDecorator`. The `--registry-overrides` flag values are merged into `imageRegistryOverrides` (the ICSP/IDMS-style `map[string][]string`, lines 154-159) instead of being wired to the inner decorator. The outer decorator has the merged values and may handle the override successfully — this workaround's sufficiency on AKS is unverified.
 
-- **ICSP/IDMS:** Protected — outer decorator applies overrides including the merged flag values
-- **`--registry-overrides`:** Broken natively — inner decorator receives `nil`, flag values are rerouted through ICSP/IDMS semantics
+- **ICSP/IDMS:** Outer decorator has merged flag values
+- **`--registry-overrides`:** Inner decorator receives `nil`, flag values rerouted through ICSP/IDMS semantics
+- **Reproduction:** R5 in Phase 0 — may work via the outer decorator workaround
 
-#### Finding 5: `RegistryClientImageMetadataProvider` — Systemic Root Cause
+#### Hypothesis 5: `RegistryClientImageMetadataProvider` — Systemic Root Cause of H1/H2
 
 **File:** `support/util/imagemetadata.go:115-119`
 
-The struct has `OpenShiftImageRegistryOverrides map[string][]string` but **no field for `--registry-overrides`** (`map[string]string`). Every method (`ImageMetadata`, `GetOverride`, `GetDigest`, `GetManifest`, `GetMetadata`) calls `SeekOverride()` which only processes ICSP/IDMS entries. This is the root cause of Findings 1 and 2 — any caller that resolves images through the metadata provider bypasses `--registry-overrides` entirely.
+The struct has `OpenShiftImageRegistryOverrides map[string][]string` but **no field for `--registry-overrides`** (`map[string]string`). Every method (`ImageMetadata`, `GetOverride`, `GetDigest`, `GetManifest`, `GetMetadata`) calls `SeekOverride()` which only processes ICSP/IDMS entries. If H1/H2 are confirmed, this is the root cause — any caller that resolves images through the metadata provider bypasses `--registry-overrides` entirely.
+
+Additionally, `GetDigest` (line 205) and `GetMetadata` (line 288) have **early-return paths** gated on `len(r.OpenShiftImageRegistryOverrides) == 0`. When ICSP/IDMS is empty (non-OpenShift clusters), these methods return immediately — bypassing `SeekOverride()` entirely. Any `--registry-overrides` support added to this struct must be applied **before** these early-return conditions, and the conditions themselves must be updated to also check the new `RegistryOverrides` field.
 
 - **ICSP/IDMS:** Protected by design — every method calls `SeekOverride()`
 - **`--registry-overrides`:** Not supported at all
+- **Reproduction:** Validated indirectly via R2/R3 in Phase 0
 
-#### Impact Matrix
+#### Hypothesis 6: HCCO Release Provider — Broken Natively (→ R6)
 
-| Code Path | Component | `--registry-overrides` | ICSP/IDMS | Severity |
-|-----------|-----------|----------------------|-----------|----------|
-| `Lookup()` (release info) | HO HC Reconciler | **Fixed** (decorator fix) | Works | Resolved |
-| `DetermineHostedClusterPayloadArch` | HO HC Reconciler | **Broken** — no metadata support | Works | FATAL — blocks before fix is reached |
-| `GetDigest` for Progressing | HO HC Reconciler | **Broken** — no metadata support | Works | Operationally fatal |
-| Karpenter controller `Lookup` | Karpenter Operator | **Broken** — bare provider | **Also broken** | FATAL |
-| Karpenter ignition `Lookup` | Karpenter Operator | Broken natively (`nil`) | Works (via workaround) | Broken on non-OpenShift |
-| NodePool reconciler (all paths) | HO NodePool Reconciler | Works | Works | OK |
-| CPO `cpReleaseProvider` | CPO | Works | Works | OK |
-| CPO `userReleaseProvider` | CPO | `nil` (intentional) | Works | OK (by design) |
-| Ignition server | Ignition Server | Works | Works | OK |
+**File:** `control-plane-operator/hostedclusterconfigoperator/cmd.go:272`
+
+The HCCO release provider chain has `RegistryOverrides: nil` on its `RegistryMirrorProviderDecorator` (line 272). HCCO accepts `--registry-overrides` (line 156) and stores the values in `o.registryOverrides`, but instead of wiring them to the inner decorator, merges them into `imageRegistryOverrides` (lines 252-261) — the ICSP/IDMS-style `map[string][]string`. The inner `RegistryMirrorProviderDecorator` receives `nil` for `RegistryOverrides`, so its native string-replacement path is disabled.
+
+This is the **exact same pattern** as Finding 4 (karpenter ignition controller): the `--registry-overrides` flag value exists on the struct (`o.registryOverrides`, line 123) but is rerouted through ICSP/IDMS semantics instead of being wired to the mechanism designed for it. On non-OpenShift management clusters where ICSP/IDMS infrastructure is unavailable, the workaround through the outer decorator may function (since the merged values are present), but the native mechanism is definitively broken.
+
+HCCO is a **core production component** — it runs inside every hosted control plane and reconciles resources in the hosted cluster. Unlike karpenter (which is opt-in), HCCO is always deployed. Any failure in HCCO's release provider affects every hosted cluster on a non-OpenShift management cluster using `--registry-overrides` with nightly releases.
+
+- **ICSP/IDMS:** Outer decorator has merged flag values — may function as workaround
+- **`--registry-overrides` native path:** Broken — inner decorator receives `nil`, flag values rerouted through ICSP/IDMS semantics
+- **Reproduction:** R6 in Phase 0
+- **Risk if unfixed:** Even if the outer decorator workaround functions today, it changes `--registry-overrides` semantics (adds 15s mirror probing timeout, availability caching, fallback ordering). Any future refactor that splits the mechanisms or removes the merge workaround would silently break HCCO. The fix is trivial (one-line wire) and eliminates this fragility.
+
+#### Impact Matrix (Hypothesized — Pending Phase 0)
+
+| Code Path | Component | `--registry-overrides` | ICSP/IDMS | Hypothesized Severity | Repro Row |
+|-----------|-----------|----------------------|-----------|-----------------------|-----------|
+| `Lookup()` (release info) | HO HC Reconciler | **Fixed** (commit c804b0c17) | Works | **Confirmed** — resolved | — |
+| `DetermineHostedClusterPayloadArch` | HO HC Reconciler | No metadata support | Works | Potentially FATAL | R2 |
+| `GetDigest` for Progressing | HO HC Reconciler | No metadata support | Works | Potentially operationally fatal | R3 |
+| Karpenter controller `Lookup` | Karpenter Operator | Bare provider, no decorators | No decorators | Potentially FATAL | R4 |
+| Karpenter ignition `Lookup` | Karpenter Operator | `nil` (workaround in outer) | Works (via workaround) | Broken natively — needs repro | R5 |
+| HCCO `Lookup` (release info) | HCCO | `nil` (workaround in outer) | Works (via workaround) | Broken natively — core production component, always deployed | R6 |
+| NodePool reconciler (all paths) | HO NodePool Reconciler | Works | Works | OK | — |
+| CPO `cpReleaseProvider` | CPO | Works | Works | OK | — |
+| CPO `userReleaseProvider` | CPO | `nil` (intentional) | Works | OK (by design) | — |
+| Ignition server | Ignition Server | Works | Works | OK | — |
 
 ---
 
 ## Components and Interfaces
 
-### Modified Components
+### Confirmed Fix (Phase 1)
 
 #### Fix 1: `RegistryMirrorProviderDecorator.Lookup()` — `support/releaseinfo/registry_mirror_provider.go:26-46`
 
 Apply `RegistryOverrides` string replacement to the `image` parameter **before** calling `p.Delegate.Lookup()`, in addition to the existing post-processing of component image tags.
 
-#### Fix 2: `RegistryClientImageMetadataProvider` — `support/util/imagemetadata.go:115-119`
+**Status:** Implemented in commit `c804b0c17`. Lands regardless of Phase 0 results.
 
-Add a `RegistryOverrides map[string]string` field. Apply simple string replacement to the image reference **before** calling `SeekOverride()` in each method (`ImageMetadata`, `GetOverride`, `GetDigest`, `GetManifest`, `GetMetadata`). This ensures `--registry-overrides` is applied in the image metadata path, resolving Findings 1 and 2.
+### Conditional Fixes (Phase 2 — Pending Phase 0 Reproduction)
 
-#### Fix 3: Karpenter controller wiring — `karpenter-operator/main.go:127-131`
+The following fixes are applied only if their corresponding reproduction rows confirm a real failure.
 
-Replace the bare `&releaseinfo.RegistryClientProvider{}` with the full decorator chain, matching the pattern already used for the karpenter ignition controller at lines 161-172. This resolves Finding 3.
+#### Fix 2: `RegistryClientImageMetadataProvider` — `support/util/imagemetadata.go:115-119` (if R2/R3 confirmed)
 
-#### Fix 4: Karpenter ignition controller wiring — `karpenter-operator/main.go:169`
+Add a `RegistryOverrides map[string]string` field. Apply simple string replacement to the image reference at the **top of each method**, before any early-return logic or `reference.Parse()` calls. This is critical because `GetDigest` (line 205) and `GetMetadata` (line 288) have early-return paths gated on `len(r.OpenShiftImageRegistryOverrides) == 0` — on non-OpenShift clusters, these methods bypass `SeekOverride()` entirely.
 
-Wire `registryOverrides` to `RegistryMirrorProviderDecorator.RegistryOverrides` instead of (or in addition to) merging into the ICSP/IDMS map. This resolves Finding 4.
+**Implementation detail for `GetDigest` (lines 188-249):**
 
-#### Fix 5: `RegistryClientImageMetadataProvider` wiring — all instantiation sites
+The current `GetDigest` control flow on non-OpenShift clusters (empty `OpenShiftImageRegistryOverrides`) is:
+
+```
+GetDigest(imageRef) →
+  Parse(imageRef)                                        // line 198
+  if len(OpenShiftImageRegistryOverrides) == 0 {         // line 205 — TRUE on non-OpenShift
+    if cache hit for imageRef → return cached digest      // lines 207-209
+    ref = &parsedImageRef                                 // line 212
+  }                                                       // falls through to line 216
+  ref = SeekOverride(OpenShiftImageRegistryOverrides, parsedImageRef, ...)  // line 216 — NO-OP (empty map)
+  // continues with unoverridden ref...
+```
+
+The early-return at line 205 has two effects when the condition is true:
+1. **Cache-hit path (line 207-209):** Returns immediately with the **unoverridden** `imageRef` digest. If `--registry-overrides` string replacement has not yet been applied, the cache lookup uses the wrong key (original registry, not mirror) and the returned reference points to the wrong registry.
+2. **Cache-miss path (line 212):** Sets `ref = &parsedImageRef` and falls through to line 216, where `SeekOverride()` is a no-op (empty ICSP/IDMS map). Execution continues using the **unoverridden** parsed reference, causing `getRepoSetup` at line 225 to connect to the original registry.
+
+**Required changes:**
+
+1. Apply `--registry-overrides` string replacement to `imageRef` at the **top of the method** (before `reference.Parse(imageRef)` at line 198). This ensures every subsequent use of `imageRef` and `parsedImageRef` operates on the overridden value.
+
+2. Update the early-return condition at line 205 from:
+```go
+if len(r.OpenShiftImageRegistryOverrides) == 0 {
+```
+to:
+```go
+if len(r.OpenShiftImageRegistryOverrides) == 0 && len(r.RegistryOverrides) == 0 {
+```
+This ensures the early-return block is only entered when **neither** override mechanism is configured. When `RegistryOverrides` is non-empty (even if ICSP/IDMS is empty), execution must fall through to `SeekOverride()` — which is a no-op for ICSP/IDMS but ensures the method follows the normal code path where the already-overridden `imageRef` is processed correctly.
+
+Without both changes, `GetDigest` would have **no effect** from Fix 2 for the target scenario: on non-OpenShift clusters, `OpenShiftImageRegistryOverrides` is empty, so the early-return fires, and even if `imageRef` was rewritten at the top, the cache-hit path returns before `SeekOverride()` is reached, while the cache-miss path sets `ref` from `parsedImageRef` (which IS correct if the replacement was applied before `Parse`). The condition update is still necessary because without it, the cache-hit path on line 207-209 checks `digestCache.Get(imageRef)` — which now contains the **overridden** imageRef — but then returns at line 209 with `parsedImageRef.ID` set from the cached digest. If the condition is not updated and `RegistryOverrides` is non-empty, the early-return block bypasses the `SeekOverride` + `getRepoSetup` path that would be reached on cache miss, creating inconsistent behavior between cache-hit and cache-miss.
+
+**Implementation detail for `GetMetadata` (lines 281-302):**
+
+The current `GetMetadata` early-return at line 288 is **unconditional** — it does not check the cache:
+
+```
+GetMetadata(imageRef) →
+  if len(OpenShiftImageRegistryOverrides) == 0 {         // line 288 — TRUE on non-OpenShift
+    return getMetadata(ctx, imageRef, pullSecret)          // line 289 — returns immediately
+  }
+  // lines 291+ are NEVER reached on non-OpenShift
+```
+
+This is the **most critical early-return** because it is unconditional: when the condition is true, `SeekOverride()` at line 298 is NEVER executed regardless of cache state. The `imageRef` passed to `getMetadata()` at line 289 is the raw, unoverridden value.
+
+**Required changes (same pattern as `GetDigest`):**
+
+1. Apply `--registry-overrides` string replacement to `imageRef` at the **top of the method**, before the early-return at line 288.
+
+2. Update the condition from:
+```go
+if len(r.OpenShiftImageRegistryOverrides) == 0 {
+```
+to:
+```go
+if len(r.OpenShiftImageRegistryOverrides) == 0 && len(r.RegistryOverrides) == 0 {
+```
+
+With both changes: when `RegistryOverrides` is non-empty and ICSP/IDMS is empty, the condition is false, execution falls through to `SeekOverride()` (a no-op for ICSP/IDMS), and `getMetadata()` at line 300 receives the overridden `composedRef`. Alternatively, if only the string replacement is applied at the top, the early-return path at line 289 would pass the **already-overridden** `imageRef` to `getMetadata()`, which also produces the correct result. Both changes together provide defense-in-depth.
+
+**Implementation detail for `ImageMetadata`, `GetOverride`, `GetManifest`:** These methods call `SeekOverride()` unconditionally (no early-return path) but `--registry-overrides` replacement must still be applied to `imageRef` before `reference.Parse()`, so the parsed reference passed to `SeekOverride()` already contains the overridden registry.
+
+**Override ordering note:** In the release info decorator chain, ICSP/IDMS (outer decorator) runs first, then `--registry-overrides` (inner decorator) runs second. In the metadata provider, `--registry-overrides` string replacement is applied first (at the top of each method), then `SeekOverride()` for ICSP/IDMS runs second. This means the precedence between the two mechanisms is **reversed** between the release info and metadata paths. On non-OpenShift clusters (the target scenario for this epic) this is irrelevant because ICSP/IDMS is empty, so `SeekOverride()` is a no-op and only `--registry-overrides` has any effect. On dual-mechanism deployments where the same source registry is matched by both mechanisms, the reversed precedence could produce different override results depending on the code path. This is documented as a known limitation — see the Risks and Known Limitations section.
+
+This resolves Hypotheses 1, 2, and 5 if R2/R3 are confirmed.
+
+#### Fix 3: Karpenter controller wiring — `karpenter-operator/main.go:127-131` (if R4 confirmed)
+
+Replace the bare `&releaseinfo.RegistryClientProvider{}` with the full decorator chain, matching the pattern already used for the karpenter ignition controller at lines 161-172. This resolves Hypothesis 3.
+
+#### Fix 4: Karpenter ignition controller wiring — `karpenter-operator/main.go:169` (if R5 confirmed)
+
+Wire `registryOverrides` to `RegistryMirrorProviderDecorator.RegistryOverrides` instead of (or in addition to) merging into the ICSP/IDMS map. This resolves Hypothesis 4. **Note:** R5 may show the outer decorator workaround is sufficient, in which case this fix is unnecessary.
+
+#### Fix 5: `RegistryClientImageMetadataProvider` wiring — all instantiation sites (if R2/R3 confirmed)
 
 Pass `registryOverrides` to the new `RegistryOverrides` field on `RegistryClientImageMetadataProvider` at each instantiation site:
 
@@ -164,6 +306,22 @@ Pass `registryOverrides` to the new `RegistryOverrides` field on `RegistryClient
 | CPO | `control-plane-operator/main.go:479` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
 | HCCO | `hostedclusterconfigoperator/cmd.go:277` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
 | Ignition server | `ignition-server/cmd/start.go:155` | ICSP/IDMS only | Add `RegistryOverrides: registryOverrides` |
+
+#### Fix 6: HCCO release provider wiring — `control-plane-operator/hostedclusterconfigoperator/cmd.go:272`
+
+Wire `o.registryOverrides` to `RegistryMirrorProviderDecorator.RegistryOverrides` at line 272 (currently `nil`). HCCO accepts `--registry-overrides` (line 156), stores it as `o.registryOverrides` (line 123), but currently only merges the values into the ICSP/IDMS-style `imageRegistryOverrides` map (lines 252-261) and passes `nil` to the inner decorator's `RegistryOverrides` field.
+
+**Justification:** HCCO is a core production component deployed in every hosted control plane. Unlike karpenter (opt-in), HCCO always runs. The bug is the same class as Finding 4 (karpenter ignition) — `--registry-overrides` values exist on the struct but are routed through ICSP/IDMS semantics instead of the native mechanism. The fix is a one-line change:
+
+```go
+// Before (line 272):
+RegistryOverrides: nil,
+
+// After:
+RegistryOverrides: o.registryOverrides,
+```
+
+Even if the outer decorator workaround masks this bug in current deployments, wiring the native path is necessary to: (a) avoid silently changing `--registry-overrides` semantics by routing through ICSP/IDMS mirror probing, (b) prevent breakage if the merge workaround is ever refactored out, and (c) maintain consistency with the fix applied to karpenter's equivalent pattern (Fix 4). This resolves Hypothesis 6.
 
 ### Interface Contracts (Unchanged)
 
@@ -190,7 +348,7 @@ The following callers instantiate `RegistryClientProvider` directly, bypassing t
 
 | Caller | File | Risk | Scope Decision |
 |--------|------|------|----------------|
-| karpenter-operator Reconciler | `karpenter-operator/main.go:130` | **Production** — same bug on nightly releases | **In scope** — Fix 3 wraps in decorator chain |
+| karpenter-operator Reconciler | `karpenter-operator/main.go:130` | **Production** — same bug class | **Conditional** — Fix 3 if R4 confirmed |
 | `hypershift create nodepool` CLI | `cmd/nodepool/core/create.go:82` | **Production** — CLI validation path | Out of scope — follow-up issue |
 | NodePool upgrade E2E test | `test/e2e/nodepool_upgrade_test.go:166` | Low — test infra | Out of scope |
 | Karpenter E2E test | `test/e2e/karpenter_test.go:481` | Low — test infra | Out of scope |
@@ -293,29 +451,39 @@ With the override applied, the registry client connects to the mirror registry (
 **When** an override matches and the image reference is rewritten before delegation
 **Then** an INFO-level log line is emitted showing the original image and the overridden image, matching the logging pattern established by `ProviderWithOpenShiftImageRegistryOverridesDecorator` (which logs at `registry_image_content_policies.go:42`)
 
-### AC8: Image metadata path supports `--registry-overrides`
+### Conditional Acceptance Criteria (Phase 2 — Applied Only If Corresponding Reproduction Confirms Failure)
+
+### AC8: Image metadata path supports `--registry-overrides` (if R2/R3 confirmed)
 
 **Given** `RegistryClientImageMetadataProvider` configured with `--registry-overrides` mapping `quay.io/openshift-release-dev/ocp-release-nightly` to an accessible mirror
 **When** `ImageMetadata()`, `GetDigest()`, or `GetManifest()` is called with a nightly release image
 **Then** the override is applied to the image reference before registry access, and the call succeeds against the mirror
 
-### AC9: `DetermineHostedClusterPayloadArch` succeeds on non-OpenShift clusters
+### AC9: `DetermineHostedClusterPayloadArch` succeeds on non-OpenShift clusters (if R2 confirmed)
 
 **Given** a non-OpenShift management cluster with `--registry-overrides` configured for nightly images
 **When** a HostedCluster is created with a nightly OCP release
 **Then** `DetermineHostedClusterPayloadArch` resolves the payload architecture successfully without `ValidReleaseImage=False`
 
-### AC10: Karpenter controller uses decorator chain
+### AC10: Karpenter controller uses decorator chain (if R4 confirmed)
 
 **Given** the karpenter-operator configured with `--registry-overrides`
 **When** the karpenter controller reconciles a HostedControlPlane with a nightly release
 **Then** the `ReleaseProvider.Lookup()` call applies registry overrides (not bare `RegistryClientProvider`)
 
-### AC11: Karpenter ignition controller wires `--registry-overrides` natively
+### AC11: Karpenter ignition controller wires `--registry-overrides` natively (if R5 confirmed)
 
 **Given** the karpenter-operator configured with `--registry-overrides`
 **When** the karpenter ignition controller processes a release image lookup
 **Then** `RegistryMirrorProviderDecorator.RegistryOverrides` is populated (not `nil`) and overrides are applied via native string replacement
+
+### AC12: HCCO release provider wires `--registry-overrides` natively
+
+**Given** HCCO configured with `--registry-overrides`
+**When** HCCO's release provider processes a release image lookup
+**Then** `RegistryMirrorProviderDecorator.RegistryOverrides` is populated with `o.registryOverrides` (not `nil`) and overrides are applied via native string replacement, independent of ICSP/IDMS availability
+
+**Note:** HCCO is a core production component deployed in every hosted control plane. This AC is not conditional on R6 reproduction — the native mechanism is definitively broken (`RegistryOverrides: nil` at `cmd.go:272`), and the fix is a one-line wire that eliminates fragility regardless of whether the outer decorator workaround masks the failure in current deployments.
 
 ---
 
@@ -323,31 +491,45 @@ With the override applied, the registry client connects to the mirror registry (
 
 ### Blast Radius
 
-The changes span two support packages and three wiring sites:
+**Phase 1 (confirmed):**
 
 | Change | Files | Nature |
 |--------|-------|--------|
 | Fix 1: `RegistryMirrorProviderDecorator.Lookup()` | 1 file | Behavioral — apply override before delegation |
-| Fix 2: `RegistryClientImageMetadataProvider` | 1 file | Structural — add `RegistryOverrides` field, apply in 5 methods |
-| Fix 3: Karpenter controller wiring | 1 file | Wiring — replace bare provider with decorator chain |
-| Fix 4: Karpenter ignition wiring | 1 file | Wiring — populate `RegistryOverrides` field |
-| Fix 5: Metadata provider wiring | 5 files | Wiring — pass `registryOverrides` to metadata provider |
 
-No interface changes, no new dependencies, no configuration changes. The `RegistryClientImageMetadataProvider` struct gains one new field — existing callers that don't set it get the zero value (`nil`), preserving current behavior.
+**Phase 2 (conditional on Phase 0 reproduction):**
+
+| Change | Files | Nature | Condition |
+|--------|-------|--------|-----------|
+| Fix 2: `RegistryClientImageMetadataProvider` | 1 file | Structural — add `RegistryOverrides` field, apply in 5 methods | R2/R3 confirmed |
+| Fix 3: Karpenter controller wiring | 1 file | Wiring — replace bare provider with decorator chain | R4 confirmed |
+| Fix 4: Karpenter ignition wiring | 1 file | Wiring — populate `RegistryOverrides` field | R5 confirmed |
+| Fix 5: Metadata provider wiring | 5 files | Wiring — pass `registryOverrides` to metadata provider | R2/R3 confirmed |
+| Fix 6: HCCO release provider wiring | 1 file | Wiring — populate `RegistryOverrides` field | R6 confirmed |
+
+No interface changes, no new dependencies, no configuration changes. If Fix 2 is applied, the `RegistryClientImageMetadataProvider` struct gains one new field — existing callers that don't set it get the zero value (`nil`), preserving current behavior.
 
 ### Behavioral Changes
+
+**Phase 1 (confirmed):**
 
 | Scenario | Before | After |
 |----------|--------|-------|
 | Nightly release + `--registry-overrides` + non-OpenShift cluster | **FAILS** — pulls from original registry | **WORKS** — pulls from mirror |
-| Payload arch detection + `--registry-overrides` + non-OpenShift | **FAILS** — `ValidReleaseImage=False`, reconciliation halted | **WORKS** — metadata provider applies override |
-| GetDigest for Progressing + `--registry-overrides` + non-OpenShift | **FAILS** — stuck Progressing condition | **WORKS** — metadata provider applies override |
-| Karpenter controller + any override config | **FAILS** — bare provider, no overrides | **WORKS** — full decorator chain |
-| Karpenter ignition + `--registry-overrides` (native path) | **BROKEN** — `RegistryOverrides: nil` | **WORKS** — field populated |
 | GA release + `--registry-overrides` (no matching entry) | Works (public access) | Works (unchanged — no override match) |
 | Any release + ICSP/IDMS on OpenShift cluster | Works (outer decorator handles) | Works (unchanged — outer decorator runs first) |
 | Any release + no overrides configured | Works | Works (unchanged — empty map, no replacements) |
 | Component image tags in ImageStream | Overridden | Overridden (preserved) |
+
+**Phase 2 (conditional — applied only if reproduction confirms failure):**
+
+| Scenario | Hypothesized Before | After (if fix applied) | Condition |
+|----------|---------------------|------------------------|-----------|
+| Payload arch detection + `--registry-overrides` + non-OpenShift | `ValidReleaseImage=False`, reconciliation halted | Metadata provider applies override | R2 |
+| GetDigest for Progressing + `--registry-overrides` + non-OpenShift | Stuck Progressing condition | Metadata provider applies override | R3 |
+| Karpenter controller + any override config | Bare provider, no overrides | Full decorator chain | R4 |
+| Karpenter ignition + `--registry-overrides` (native path) | `RegistryOverrides: nil` | Field populated | R5 |
+| HCCO + `--registry-overrides` (native path) | `RegistryOverrides: nil` | Field populated with `o.registryOverrides` | R6 |
 
 ### Cache Impact
 
@@ -376,6 +558,25 @@ Go `map` iteration order is non-deterministic. If `RegistryOverrides` contains t
 This is a **pre-existing limitation** — the same non-determinism exists in the current tag post-processing loop (lines 36-39 of `registry_mirror_provider.go`). The fix inherits this behavior; it does not introduce new non-determinism. In practice, operators configure non-overlapping override entries (one source prefix per mirror), so this is unlikely to manifest.
 
 **No mitigation in this epic.** If this needs to be addressed, it should be a separate effort that sorts map keys by specificity (longest prefix first) across both code paths.
+
+### Known limitation: Override ordering inconsistency between release info and metadata paths
+
+Fix 2 introduces a precedence reversal between the release info and metadata code paths:
+
+| Path | First override applied | Second override applied |
+|------|----------------------|------------------------|
+| Release info (decorator chain) | ICSP/IDMS (outer `ProviderWithOpenShiftImageRegistryOverridesDecorator`) | `--registry-overrides` (inner `RegistryMirrorProviderDecorator`) |
+| Image metadata (Fix 2) | `--registry-overrides` (string replacement at top of method) | ICSP/IDMS (`SeekOverride()` called after) |
+
+**Concrete example of divergent behavior:** If an operator configures both ICSP/IDMS mapping `quay.io/foo` to `mirror-a/foo` and `--registry-overrides=quay.io/foo=mirror-b/foo`, then:
+- Release info path: ICSP/IDMS rewrites to `mirror-a/foo` first; `--registry-overrides` does not match `mirror-a/foo`, so the result is `mirror-a/foo`.
+- Metadata path: `--registry-overrides` rewrites to `mirror-b/foo` first; `SeekOverride()` does not match `mirror-b/foo`, so the result is `mirror-b/foo`.
+
+This means the same image could be resolved to **different mirrors** depending on whether it goes through the release info path or the metadata path.
+
+**On non-OpenShift clusters (the target scenario for this epic), this is irrelevant** — ICSP/IDMS is empty, so `SeekOverride()` is a no-op and only `--registry-overrides` has any effect. The inconsistency would only manifest on OpenShift management clusters that have **both** ICSP/IDMS policies **and** `--registry-overrides` configured simultaneously, where the same source registry is matched by both mechanisms. In practice, this dual-mechanism configuration is uncommon — ICSP/IDMS is the preferred mechanism on OpenShift clusters, and `--registry-overrides` is primarily used on non-OpenShift clusters where ICSP/IDMS is unavailable.
+
+**No code change in this epic.** The reversal is an inherent consequence of bolting `--registry-overrides` support onto the metadata provider as a string replacement (the only viable approach without a larger refactor). The unified registry override abstraction (see Follow-up section) should resolve this by establishing a single, consistent ordering across all code paths.
 
 ### Known limitation: CLI `nodepool create` bare provider
 

--- a/projects/hypershift/reports/2026-04-21-ocpbugs-82112-mass-ci-failures.md
+++ b/projects/hypershift/reports/2026-04-21-ocpbugs-82112-mass-ci-failures.md
@@ -1,0 +1,546 @@
+# Root Cause Analysis: HyperShift Mass CI Test Failures
+
+**JIRA:** [OCPBUGS-82112](https://redhat.atlassian.net/browse/OCPBUGS-82112)  
+**Management Cluster:** `hypershift-ci-3` (ROSA, us-east-1)  
+**Report Date:** 2026-04-21
+
+---
+
+## TL;DR
+
+### Root Cause
+
+The management cluster (`hypershift-ci-3`) has two NodePools:
+
+- **`ci`** — m7a.4xlarge (64 GB), tainted `NoSchedule` for hosted cluster control planes
+- **`workers`** — m7a.2xlarge (32 GB), **untainted** — all cluster infrastructure lands here
+
+Two compounding problems:
+- **Sizing:** Prometheus alone consumes 8–15 GB on a 32 GB node, leaving little room for anything else. Even without HCP spillover, infra can reach ~18 GB — over half the node.
+- **Scheduling:** The taint blocks infra from `ci` nodes, but nothing blocks HCP pods from `workers` nodes. When HCP pods spill onto `workers`, they compete with an already memory-heavy infra stack for the remaining headroom.
+
+### What Happens Under CI Load
+
+- CI batch creates 10+ hosted clusters simultaneously
+- Scheduler spreads HCP pods across **all** eligible nodes, including all 3 `workers`
+- Memory requests hit 29 of 31 GB allocatable on each `workers` node
+- MemFree drops to ~500 MB — the OS freezes all processes to reclaim pages
+- Kubelet can't execute liveness probes for **any** pod on the node
+- CoreDNS gets killed despite being healthy
+
+### Thundering Herd
+
+This isn't a single-node failure. The same CI batch overwhelms all 3 `workers` nodes at once:
+- **2 of 3 DNS pods down simultaneously** at 01:54, 02:23, 02:36, 02:38 UTC
+- A single DNS pod served the entire management cluster at those moments
+- DNS was degraded (2 or fewer pods) for **over 2 hours** (00:34–02:46)
+- If scheduling had been slightly different, all 3 could have failed — **total DNS blackout**
+
+```mermaid
+sequenceDiagram
+    participant CI as CI Batch
+    participant Sched as Scheduler
+    participant Node as 🖥️ Node<br/>m7a.2xlarge · 32 GB
+    participant Kubelet as Kubelet
+    participant DNS as CoreDNS<br/>(healthy)
+    participant HCs as All Hosted<br/>Clusters
+
+    Note over Node: Already running:<br/>Prometheus (13 GB)<br/>HO, router, registry
+
+    CI->>Sched: Create 10+ hosted clusters
+    Sched->>Node: HCP pods (KAS, etcd...)
+    Sched->>Node: More HCP pods arrive
+
+    Note over Node: 29 of 31 GB allocated<br/>Only 500 MB actually free<br/>OS starts freezing processes<br/>to reclaim memory
+
+    Kubelet->>DNS: Liveness probe
+    Note over Kubelet: Probe HTTP request<br/>needs memory allocation<br/>→ frozen by OS
+
+    Note over Kubelet: Also probing every<br/>other pod on this node<br/>ALL frozen simultaneously
+
+    Kubelet--xDNS: ⏱️ timeout (5s)
+
+    Kubelet-xDNS: ❌ KILL POD (liveness failed)
+    Note over DNS: CoreDNS was healthy.<br/>Kubelet couldn't reach it.
+
+    Note over Node: DNS: 3 pods → 2 pods<br/>1,500 qps on 2 pods
+
+    HCs->>DNS: DNS queries
+    DNS--xHCs: ❌ FAIL — timeout / no such host
+    Note over HCs: All DNS-dependent<br/>operations fail across<br/>every hosted cluster
+```
+
+**Not a HyperShift code bug.** CI infrastructure taint/sizing issue.
+
+### How We Got the Data
+
+We had a kubeconfig for the management cluster (`hypershift-ci-3`) and used three data sources:
+
+1. **Prometheus/Thanos** on the management cluster — memory metrics, pod counts, DNS query rates, kubelet probe failure counters (`prober_probe_total`), memory request totals (`kube_pod_container_resource_requests`). Retention starts Apr 20 18:04 UTC.
+2. **`oc debug node`** — non-interactive shell into each node to read kernel counters (`/proc/vmstat`, `/proc/meminfo`), `dmesg`, and `journalctl -u kubelet`.
+3. **Prow job artifacts** — build logs and dump archives from GCS (`test-platform-results` bucket), accessed via HTTPS.
+
+All commands are included in collapsible sections throughout the report.
+
+### Consistent Across Every Job We Checked
+
+Same management cluster, different jobs, different OCP versions, different dates, different DNS error messages — **same pattern every time**: node memory exhaustion → CoreDNS killed → DNS-dependent operations fail.
+
+| Job | OCP | Date | DNS Symptom | Failures |
+|-----|-----|------|-------------|----------|
+| [4.22 #...130368](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-hypershift-ovn-conformance-4.22-release-openshift-release-analysis-aggregator/2046359024563130368) | 4.22 | Apr 20–21 | kube-api disruption (5/10 runs) | 6 |
+| [5.0 #...769600](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-hypershift-ovn-conformance-5.0-release-openshift-release-analysis-aggregator/2046376312783769600) | **5.0** | Apr 20–21 | `konnectivity-server-local: no such host` ×1,304 | **467** |
+| [4.22 #...243968](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-hypershift-ovn-conformance-4.22-release-openshift-release-analysis-aggregator/2046459091324243968) | 4.22 | Apr 21 | `konnectivity-server-local: no such host` | 4 |
+| [4.22 #...750976](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-hypershift-ovn-conformance-4.22-release-openshift-release-analysis-aggregator/2044995175322750976) | 4.22 | Apr 17 | `read udp→172.30.0.10:53: i/o timeout` + etcd leader churn | 3 |
+
+The DNS error varies — `no such host`, `i/o timeout`, API disruption — because different operations hit DNS at different moments during the outage. The underlying cause is always the same: CoreDNS pod killed by liveness probe timeout on a memory-exhausted node. Severity tracks how much memory pressure the node was under when each job ran, not the OCP version or test content.
+
+---
+
+## 1. Management Cluster Architecture
+
+### The Taint Design
+
+```
+m7a.4xlarge (64 GB) — TAINTED               m7a.2xlarge (32 GB) — UNTAINTED
+┌──────────────────────────────┐          ┌──────────────────────────────┐
+│ hypershift.openshift.io/     │          │                              │
+│   control-plane:NoSchedule   │          │ Prometheus        8–15 GB   │
+│                              │          │ HyperShift Operator 0.1–1 GB│
+│ ✅ HCP pods (have toleration)│          │ kube-state-metrics   350 MB │
+│ ❌ Prometheus                │          │ CoreDNS, Router, Registry   │
+│ ❌ CoreDNS                   │          │ Alertmanager, Thanos        │
+│ ❌ Router, Registry          │          │                              │
+│ ❌ HyperShift Operator       │          │ ✅ HCP pods ALSO land here  │
+│                              │          │    (taint doesn't block this)│
+│ 5 nodes, well-provisioned    │          │                              │
+│ Up to 322 pods, zero issues  │          │ 3 nodes, structurally starved│
+└──────────────────────────────┘          └──────────────────────────────┘
+```
+
+The taint blocks **infra from going to 4xlarge** but does NOT block **HCP from going to 2xlarge**. The untainted nodes get hit from both sides.
+
+<details><summary>Commands: taint and toleration inspection</summary>
+
+```bash
+# Node taints
+for node in $(KUBECONFIG=<path-to-kubeconfig> oc get nodes -o jsonpath='{.items[*].metadata.name}'); do
+  taints=$(KUBECONFIG=<path-to-kubeconfig> oc get node $node -o jsonpath='{.spec.taints}')
+  type=$(KUBECONFIG=<path-to-kubeconfig> oc get node $node -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}')
+  echo "$node ($type): taints=${taints:-<none>}"
+done
+
+# Prometheus tolerations
+KUBECONFIG=<path-to-kubeconfig> oc get pod prometheus-k8s-0 -n openshift-monitoring -o jsonpath='{.spec.tolerations}'
+
+# CoreDNS tolerations
+KUBECONFIG=<path-to-kubeconfig> oc get pod dns-default-kfhmt -n openshift-dns -o jsonpath='{.spec.tolerations}'
+```
+</details>
+
+### Node Inventory
+
+Two ROSA NodePools:
+
+| NodePool | Type | RAM | Tainted | Nodes | Scales? |
+|----------|------|-----|---------|-------|---------|
+| **`hypershift-ci-3-workers`** | m7a.2xlarge | 32 GB | No | 3 (one per AZ) | No — static minimum |
+| **`hypershift-ci-3-ci`** | m7a.4xlarge | 64 GB | Yes | 5–8 | Yes — autoscaler |
+
+| Node | NodePool | AZ |
+|------|----------|----|
+| ip-10-0-135-91 | `workers` | us-east-1a |
+| ip-10-0-153-209 | `workers` | us-east-1b |
+| ip-10-0-171-26 | `workers` | us-east-1c |
+| ip-10-0-137-180 | `ci` | us-east-1a |
+| ip-10-0-157-94 | `ci` | us-east-1b |
+| ip-10-0-158-179 | `ci` | us-east-1b |
+| ip-10-0-160-247 | `ci` | us-east-1c |
+| ip-10-0-164-186 | `ci` | us-east-1c |
+
+The `workers` pool never scales down. The `ci` pool scales with demand (8 nodes on Apr 17, 5 on Apr 21).
+
+### DNS Topology
+
+3 CoreDNS pods (DaemonSet), one per untainted node, serving 172.30.0.10. All DNS for the management cluster goes through these 3 pods. Baseline load: ~1,500 qps, 74% NXDOMAIN from `ndots:5` search path walks.
+
+<details><summary>Commands: DNS topology and query rates</summary>
+
+```bash
+# DNS pods and placement
+KUBECONFIG=<path-to-kubeconfig> oc get pods -n openshift-dns -o wide
+
+# DNS query rate by response code
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  "${THANOS}/api/v1/query" \
+  --data-urlencode 'query=sum by (rcode)(rate(coredns_dns_responses_total[5m]))'
+
+# KAS resolv.conf (ndots:5 confirmation)
+KUBECONFIG=<path-to-kubeconfig> oc exec -n clusters-<hcp-ns> <kas-pod> \
+  -c kube-apiserver -- cat /etc/resolv.conf
+```
+</details>
+
+---
+
+## 2. What Happens Under CI Load
+
+When a CI batch creates 10+ hosted clusters, HCP pods (KAS, etcd, controllers) schedule across the cluster. The 4xlarge nodes absorb most of them (they have the toleration), but pods also spill onto the untainted 2xlarge nodes. Combined with the infra workload already there, total memory requests approach the node's allocatable capacity.
+
+### Memory State at Failure
+
+At each failure point, the node that fails has ~29 GB of memory requests against 31 GB allocatable. Actual memory breakdown:
+
+```
+Node allocatable:                31.0 GB
+Pod memory requests:            ~29.0 GB   (infra + HCP spillover)
+─────────────────────────────────────────
+Remaining allocatable:           ~2.0 GB
+
+Actual state (/proc/meminfo):
+  MemTotal:                      30.7 GB
+  Used (non-reclaimable):        26.8 GB
+  Cached (reclaimable):           3.6 GB
+  MemFree (actual free pages):    0.5 GB   ← this is the real number
+  MemAvailable:                   3.9 GB   ← misleading; includes cache
+```
+
+At **500 MB actual free pages**, the kernel enters direct reclaim.
+
+<details><summary>Commands: memory state and requests</summary>
+
+```bash
+# Memory breakdown on a node at a specific time
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query" \
+  --data-urlencode 'query={__name__=~"node_memory_MemTotal_bytes|node_memory_MemFree_bytes|node_memory_MemAvailable_bytes|node_memory_Cached_bytes",instance=~".*171-26.*"}' \
+  --data-urlencode 'time=2026-04-21T00:45:00Z'
+
+# Total memory requests per node at a point in time
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query" \
+  --data-urlencode 'query=sum by (node)(kube_pod_container_resource_requests{resource="memory", node=~"ip-10-0-135-91.*|ip-10-0-153-209.*|ip-10-0-171-26.*"}) / 1024 / 1024 / 1024' \
+  --data-urlencode 'time=2026-04-21T00:48:00Z'
+```
+</details>
+
+---
+
+## 3. The Kernel Mechanism
+
+With 500 MB MemFree, any process that allocates memory triggers **direct reclaim** — the kernel synchronously scans and evicts pages before returning the allocation. The calling process is frozen until a page is freed.
+
+Evidence from `vmstat` on `ip-10-0-135-91`:
+
+| Counter | Value | Meaning |
+|---------|-------|---------|
+| `allocstall_normal` | 2,812 | Direct reclaim stalls (process frozen waiting for memory) |
+| `allocstall_movable` | 17,934 | More stalls in the movable zone |
+| `pgsteal_direct` | 1,119,809 | Pages stolen synchronously by blocked processes |
+| `pgscan_direct` | 1,485,262 | Pages scanned during direct reclaim |
+| `pgmajfault` | 16,714,123 | Major page faults (had to read from disk) |
+| `compact_stall` | 7,979 | Memory compaction stalls |
+
+**20,746 `allocstall` events** = 20,746 times a process was frozen waiting for the kernel to free memory. The kubelet's probe goroutines are among those frozen processes.
+
+<details><summary>Commands: kernel vmstat counters</summary>
+
+```bash
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host bash -c '
+  grep -E "allocstall|pgsteal_direct|pgscan_direct|pgmajfault|compact_stall" /proc/vmstat
+  echo "---"
+  grep -E "MemTotal|MemFree|MemAvailable|Cached|SReclaimable" /proc/meminfo
+'
+```
+</details>
+
+### What the Kubelet Sees
+
+Kubelet logs from `ip-10-0-135-91` at 01:38:29–01:38:34 UTC show **every pod on the node** failing probes within a 5-second window:
+
+```
+01:38:29  CSI driver:          "context deadline exceeded"
+01:38:30  HCP controller-mgr:  "context deadline exceeded"
+01:38:30  konnectivity-agent:  "context deadline exceeded"
+01:38:30  external-dns:        "context deadline exceeded"
+01:38:30  CoreDNS (readiness): "context deadline exceeded"
+01:38:30  console:             "request canceled while waiting for connection"
+01:38:31  Prometheus:          "command timed out"
+01:38:32  CoreDNS (liveness):  "context deadline exceeded"  → KILLED
+01:38:33  Prometheus:          "command timed out"           → KILLED
+```
+
+CoreDNS was healthy. The kubelet couldn't reach it because its HTTP client was frozen waiting for a page allocation. After enough consecutive liveness failures, the kubelet kills CoreDNS. Then DNS capacity drops and downstream failures cascade.
+
+<details><summary>Commands: kubelet probe logs</summary>
+
+```bash
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host \
+  journalctl -u kubelet --since "2026-04-21 01:38" --until "2026-04-21 01:39" \
+  | grep -iE "probe|liveness|dns-default"
+```
+</details>
+
+---
+
+## 4. Evidence: Every Failure Follows This Pattern
+
+Using `prober_probe_total{result="failed", probe_type="Liveness"}` and `node_memory_MemAvailable_bytes` from the management cluster's Prometheus, we correlated every DNS probe failure with node memory state.
+
+### 6 DNS Failure Events Across 3 Jobs
+
+| # | Time | Failing Node | Requests/Alloc | MemFree | Other Nodes |
+|---|------|-------------|----------------|---------|-------------|
+| 1 | 00:48 | 171-26 | 28.8/31 GB | **0.5 GB** (MemAvail 4.0) | 135-91: 6.2, 153-209: 16.4 |
+| 2 | 01:55 | 135-91 | 28.1/31 GB | **(scrape failed)** | 171-26: 7.8, 153-209: 19.0 |
+| 3 | 02:23 | 135-91 | —/31 GB | **(scrape failed)** | 171-26: 6.4, 153-209: 20.1 |
+| 4 | 02:45 | 171-26 | —/31 GB | **~0.5 GB** (MemAvail 4.5) | 135-91: 6.7, 153-209: 17.3 |
+| 5 | 05:46 | 171-26 | 28.1/31 GB | **~0.5 GB** (MemAvail 4.2) | 135-91: 11.3, 153-209: 18.9 |
+| 6 | 05:51 | 171-26 | —/31 GB | **~0.5 GB** (MemAvail ~4) | 135-91: 10.6, 153-209: 17.7 |
+
+The failure **rotates** between `ip-10-0-135-91` and `ip-10-0-171-26` depending on which has more HCP pods at that moment. `ip-10-0-153-209` never fails — it consistently has 2–4x more headroom (fewer pods scheduled there). It's not one "sick node"; it's whichever node the scheduler loaded most heavily.
+
+<details><summary>Commands: probe failures and memory correlation</summary>
+
+```bash
+# DNS liveness probe failures at 1-minute resolution
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query_range" \
+  --data-urlencode 'query=rate(prober_probe_total{result="failed", pod=~"dns-default.*", probe_type="Liveness"}[1m]) > 0' \
+  --data-urlencode 'start=2026-04-20T22:00:00Z' \
+  --data-urlencode 'end=2026-04-21T07:00:00Z' \
+  --data-urlencode 'step=60'
+
+# Memory available on all 3 untainted nodes at a failure timestamp
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query" \
+  --data-urlencode 'query=node_memory_MemAvailable_bytes{instance=~".*135-91.*|.*153-209.*|.*171-26.*"} / 1024 / 1024 / 1024' \
+  --data-urlencode 'time=2026-04-21T00:48:00Z'
+
+# Memory requests on all 3 untainted nodes at same timestamp
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query" \
+  --data-urlencode 'query=sum by (node)(kube_pod_container_resource_requests{resource="memory", node=~"ip-10-0-135-91.*|ip-10-0-153-209.*|ip-10-0-171-26.*"}) / 1024 / 1024 / 1024' \
+  --data-urlencode 'time=2026-04-21T00:48:00Z'
+```
+</details>
+
+### Thundering Herd: Multiple DNS Pods Down Simultaneously
+
+The same CI batch hits all 3 `workers` nodes at once. At 4 points during the overnight window, **2 of 3 DNS pods were down simultaneously**:
+
+| Time | DNS Pods Up | Implication |
+|------|------------|-------------|
+| 01:54 | **1** | Single pod serving entire cluster |
+| 02:23 | **1** | Single pod serving entire cluster |
+| 02:36 | **1** | Single pod serving entire cluster |
+| 02:38 | **1** | Single pod serving entire cluster |
+| 05:45–06:22 | 2 | Third node removed by autoscaler, never recovered |
+
+From 00:34 to 02:46, DNS was degraded (2 or fewer pods) for over **2 hours**. This isn't an unlucky single-node failure — it's a systemic event where the same trigger overwhelms multiple nodes in the same pool simultaneously.
+
+<details><summary>Commands: DNS pod availability</summary>
+
+```bash
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query_range" \
+  --data-urlencode 'query=count(up{job="dns-default", namespace="openshift-dns"} == 1)' \
+  --data-urlencode 'start=2026-04-20T22:00:00Z' \
+  --data-urlencode 'end=2026-04-21T07:00:00Z' \
+  --data-urlencode 'step=60'
+```
+</details>
+
+### Co-Failure of All Pods on the Node
+
+The HyperShift operator replicas (also on untainted nodes, also don't tolerate the taint) fail probes at the **exact same times** as CoreDNS on the same node — confirming this is node-level, not pod-level:
+
+| Time Window | Node | DNS probes fail | HO probes fail | Same node? |
+|-------------|------|----------------|----------------|-----------|
+| 00:36–00:55 | 171-26 | Yes | Yes | Yes |
+| 01:41–02:41 | 135-91 | Yes | Yes | Yes |
+| 02:41–02:50 | 171-26 | Yes | Yes | Yes |
+| 05:45–06:05 | 171-26 | Yes | Yes | Yes |
+
+---
+
+## 5. Cross-Verification
+
+Covered in the TL;DR table above. The key point: 4 different jobs across 2 OCP versions, all on the same management cluster, all fail with DNS resolution errors. The DNS error message varies (`no such host`, `i/o timeout`, API disruption) because different operations hit DNS at different points during the outage. The underlying cause — CoreDNS killed by probe timeout on a memory-exhausted node — is the same every time.
+
+The 5.0 job is the most severe example — all 8 underlying runs affected, up to 1,304 DNS failures per run:
+
+| Run | DNS Failures | Test Failures |
+|-----|-------------|---------------|
+| ...718400 | **1,304** | 332 |
+| ...942208 | **630** | 538 |
+| ...102784 | 242 | 236 |
+| ...242304 | 163 | 431 |
+| ...663808 | 129 | 34 |
+| ...521216 | 93 | 460 |
+| ...580736 | 88 | 368 |
+| ...659904 | 12 | 8 |
+
+---
+
+## 6. Recommendations
+
+### Primary Fix
+
+**Upsize the `hypershift-ci-3-workers` NodePool from m7a.2xlarge (32 GB) to m7a.4xlarge (64 GB).** The `hypershift-ci-3-ci` nodes carry 300+ pods at 98% CPU with zero issues because 64 GB provides sufficient memory headroom. Giving the `workers` pool the same RAM eliminates the class of failures in this report.
+
+### Alternative Fixes
+
+**Prevent HCP pods from scheduling on untainted nodes.** The taint blocks infra from 4xlarge but not HCP from 2xlarge. Adding a complementary mechanism (taint on 2xlarge tolerated only by infra, or nodeAffinity on HCP pods requiring the 4xlarge taint) would keep HCP pods on the well-provisioned nodes. Note: this removes the ~6 GB HCP spillover but infra alone (Prometheus at 13 GB + monitoring stack + operators) already consumes ~18 GB on a 32 GB node. Prometheus growth during CI batches could still approach the threshold.
+
+**Add memory limits to infra workloads.** Prometheus has no memory limit and grows unboundedly with scrape target count. Setting a limit would cap its impact — at the cost of OOM-killing Prometheus when it hits the limit, which has its own blast radius.
+
+### Systemic Fix
+
+**Review the taint/toleration design.** The current model creates two node classes: 4xlarge (HCP-only, tainted, well-provisioned) and 2xlarge (everything-else, untainted, undersized). All cluster infrastructure competes for the smallest nodes. This is structurally fragile.
+
+### Monitoring
+
+**Alert on `allocstall` rate or MemFree < 1 GB.** MemAvailable masks the real pressure — at 4 GB MemAvailable, actual MemFree is 500 MB and the kernel is already in direct reclaim. Early detection would allow draining nodes before probes start failing.
+
+### Owner
+
+**This is a CI infrastructure issue.** File against `hypershift-ci-3` management cluster configuration, not HyperShift product code.
+
+---
+
+## 7. Appendix
+
+### Data Sources
+
+| Source | Method |
+|--------|--------|
+| Node memory, pod counts | Prometheus/Thanos on `hypershift-ci-3` (retention from Apr 20 18:04) |
+| Liveness probe failures | `prober_probe_total{result="failed", probe_type="Liveness"}` |
+| Memory requests per node | `kube_pod_container_resource_requests{resource="memory"}` |
+| DNS query rates | `coredns_dns_responses_total` by rcode |
+| Kernel direct reclaim | `vmstat` counters via `oc debug node` |
+| Kubelet probe logs | `journalctl -u kubelet` via `oc debug node` |
+| Memory breakdown | `/proc/meminfo` via `oc debug node` |
+| Node taints | `oc get nodes -o jsonpath` |
+| KAS DNS config | `/etc/resolv.conf` in KAS pod (ndots:5, search clusters-xxx.svc.cluster.local) |
+| Konnectivity Service | Verified present and correctly configured in HCP namespace dump |
+
+### Analyzed Jobs
+
+| Job | Build ID | Window |
+|-----|----------|--------|
+| aggregated-hypershift-ovn-conformance-4.22 | 2046359024563130368 | Apr 20 22:42–Apr 21 01:00 |
+| aggregated-hypershift-ovn-conformance-5.0 | 2046376312783769600 | Apr 20 23:51–Apr 21 03:47 |
+| aggregated-hypershift-ovn-conformance-4.22 | 2046459091324243968 | Apr 21 05:20–07:50 |
+
+---
+
+## 8. Deep Dive: Kernel Memory Reclaim and Kubelet Starvation
+
+This section explains the low-level mechanism by which memory pressure translates into liveness probe failures. It is not required to understand the root cause — skip this unless you want to understand **why 500 MB MemFree kills liveness probes on an otherwise healthy node**.
+
+### Why MemAvailable Is Misleading
+
+At the moment before CoreDNS is killed, `/proc/meminfo` on the failing node shows:
+
+```
+MemTotal:        30.7 GB
+MemFree:          0.5 GB   ← actual free pages
+Cached:           3.6 GB   ← page cache (reclaimable in theory)
+SReclaimable:     0.3 GB   ← slab cache (reclaimable)
+MemAvailable:     3.9 GB   ← kernel's estimate of "usable" memory
+```
+
+`MemAvailable` (3.9 GB) looks fine. But it includes 3.6 GB of page cache that the kernel must **actively evict** before any process can use it. Evicting cache is not free — it requires scanning pages, writing dirty pages to disk, and updating page tables. At 500 MB MemFree, every new memory allocation triggers this eviction synchronously.
+
+<details><summary>Commands: /proc/meminfo at failure time</summary>
+
+```bash
+# From Prometheus (at 00:45 UTC, just before failure on ip-10-0-171-26)
+curl -sk -H "Authorization: Bearer $TOKEN" "${THANOS}/api/v1/query" \
+  --data-urlencode 'query={__name__=~"node_memory_MemTotal_bytes|node_memory_MemFree_bytes|node_memory_MemAvailable_bytes|node_memory_Cached_bytes|node_memory_SReclaimable_bytes",instance=~".*171-26.*"}' \
+  --data-urlencode 'time=2026-04-21T00:45:00Z'
+
+# Live (current state)
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host \
+  grep -E "MemTotal|MemFree|MemAvailable|Cached|SReclaimable" /proc/meminfo
+```
+</details>
+
+### Direct Reclaim: When the Kernel Freezes Your Processes
+
+When a process (including the kubelet) calls `malloc()` or opens a network socket, the kernel needs to provide free pages. If MemFree is exhausted, the kernel enters **direct reclaim** — the calling process is frozen while the kernel synchronously scans and evicts pages to free memory. The process cannot continue until a page is freed.
+
+`/proc/vmstat` on `ip-10-0-135-91` shows the cumulative impact:
+
+```
+allocstall_normal    2,812     # process frozen waiting for a page (normal zone)
+allocstall_movable  17,934     # same, movable zone
+                   ──────
+                   20,746 total stall events
+
+pgsteal_direct    1,119,809    # pages forcibly reclaimed by blocked processes
+pgscan_direct     1,485,262    # pages scanned to find reclaimable ones
+pgmajfault       16,714,123    # page faults requiring disk I/O
+compact_stall         7,979    # compaction stalls (defragmenting memory)
+```
+
+20,746 times a process was frozen waiting for memory. 1.1 million pages were stolen synchronously. Each stall can last milliseconds to seconds depending on how much scanning and I/O is required.
+
+<details><summary>Commands: /proc/vmstat</summary>
+
+```bash
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host bash -c '
+  grep -E "allocstall|pgsteal_direct|pgscan_direct|pgmajfault|compact_stall" /proc/vmstat
+'
+```
+</details>
+
+### How This Kills Liveness Probes
+
+The kubelet runs liveness probes on a timer. For HTTP probes, it opens a TCP connection to the pod's health endpoint and waits for a response. Each step — socket creation, TCP handshake, HTTP request — requires memory allocations. At 500 MB MemFree, each allocation risks hitting an `allocstall`:
+
+1. Kubelet goroutine calls `net.Dial()` → needs socket buffer → **stalls 200ms** waiting for page eviction
+2. TCP handshake needs more buffers → **stalls again**
+3. Probe timeout (typically 1–5s) expires while the goroutine is frozen
+4. Kubelet records `"context deadline exceeded"`
+5. After `failureThreshold` consecutive failures → kubelet sends SIGKILL
+
+The kubelet logs from 01:38:29–01:38:34 on `ip-10-0-135-91` show this happening to **every pod on the node simultaneously** — CoreDNS, Prometheus, CSI driver, console, HCP controllers, konnectivity-agent — all with the same `"context deadline exceeded"` error within 5 seconds. This proves the bottleneck is the node (kernel memory reclaim), not any individual pod.
+
+<details><summary>Commands: kubelet logs showing simultaneous probe failures</summary>
+
+```bash
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host \
+  journalctl -u kubelet --since "2026-04-21 01:38" --until "2026-04-21 01:39" \
+  | grep -E "Probe failed.*context deadline|Probe failed.*timed out"
+```
+</details>
+
+### Kernel Logs (dmesg)
+
+`dmesg` on the failing node shows no OOM kills — the kernel never ran completely out of memory. It just made everything slow:
+
+```
+# ip-10-0-135-91 (failing node)
+2026-04-19T02:17:00 openvswitch: ovs-system: deferred action limit reached, drop recirc action
+2026-04-19T02:17:02 openvswitch: ovs-system: deferred action limit reached, drop recirc action
+  ... (20+ occurrences — OVS packet processing stalled under memory pressure)
+2026-04-20T02:06:22 systemd-journald.service: Failed with result 'watchdog'
+2026-04-20T17:42:27 systemd-journald.service: Failed with result 'watchdog'
+
+# ip-10-0-153-209 (surviving node)
+  (no OVS drops, no journald failures)
+```
+
+The OVS `deferred action limit reached` entries confirm that the kernel's network packet processing was also affected — the OVS datapath couldn't allocate memory for flow recirculations and dropped packets. The `journald` watchdog failures show that even systemd services were experiencing scheduling delays severe enough to trigger watchdog timeouts.
+
+No OOM kills occurred because `MemAvailable` never hit zero — there was always reclaimable cache. The kernel never had to kill a process for memory. Instead, it made **everything** agonizingly slow via direct reclaim stalls, which for liveness probes is worse than a clean OOM kill — at least an OOM kill would restart the right process instead of killing the wrong one (CoreDNS) due to a missed probe.
+
+<details><summary>Commands: dmesg</summary>
+
+```bash
+# Failing node
+oc debug node/ip-10-0-135-91.ec2.internal -- chroot /host \
+  dmesg --time-format iso | grep -iE "oom|openvswitch|deferred|journald.*Failed"
+
+# Surviving node (for comparison)
+oc debug node/ip-10-0-153-209.ec2.internal -- chroot /host \
+  dmesg --time-format iso | grep -iE "oom|openvswitch|deferred|journald.*Failed"
+```
+</details>

--- a/projects/hypershift/reports/2026-04-21-ocpbugs-82112-mass-ci-failures.md
+++ b/projects/hypershift/reports/2026-04-21-ocpbugs-82112-mass-ci-failures.md
@@ -8,6 +8,8 @@
 
 ## TL;DR
 
+![it was dns](https://i.imgflip.com/apshsq.jpg)
+
 ### Root Cause
 
 The management cluster (`hypershift-ci-3`) has two NodePools:


### PR DESCRIPTION
## Summary

- Defines a reopen workflow for issues that reached `done` and need to re-enter the pipeline (regression, incomplete fix, changed requirements)
- Reuses existing statuses — no new board columns needed
- Extends `close-reopen.sh` with optional `--target-status` parameter
- Design doc at `projects/botminter/knowledge/designs/epic-75.md`

## Test plan

- [ ] Verify PROCESS.md section is clear and consistent with existing conventions
- [ ] Verify `close-reopen.sh` extension is backward-compatible
- [ ] Verify board scanner needs no changes (dispatches by status value)
- [ ] Verify acceptance criteria are complete and testable

Refs: #75